### PR TITLE
Updater stack to start Fargate task on schedule

### DIFF
--- a/stacks/bottlerocket-ecs-updater.yaml
+++ b/stacks/bottlerocket-ecs-updater.yaml
@@ -1,0 +1,132 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'Bottlerocket ECS updater automation & resources'
+Parameters:
+  ClusterName:
+    Description: 'Name of ECS cluster to manage Bottlerocket instances in'
+    Type: String
+  Subnets:
+    Description: 'List of VPC Subnet IDs where the updater should run. The subnets must have a route to the Internet via an Internet Gateway.'
+    Type: List<AWS::EC2::Subnet::Id>
+  UpdaterImage:
+    Description: 'Bottlerocket updater container image'
+    Type: String
+  LogGroupName:
+    Description: 'Log group name for Bottlerocket updater logs'
+    Type: String
+Resources:
+  ExecutionRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - 'ecs-tasks.amazonaws.com'
+            Action:
+              - 'sts:AssumeRole'
+      Path: !Sub /${AWS::StackName}/
+      ManagedPolicyArns:
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy'
+  TaskRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Description: 'Role allowing the Bottlerocket ECS Updater to manage Bottlerocket instances'
+      Path: !Sub '/${AWS::StackName}/'
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: 'ecs-tasks.amazonaws.com'
+            Action:
+              - 'sts:AssumeRole'
+      Policies:
+        - PolicyName: 'BottlerocketEcsUpdaterPolicy'
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'ecs:ListContainerInstances'
+                Resource:
+                  - !Sub 'arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}'
+  UpdaterTaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      Cpu: 256
+      Memory: 0.5GB
+      ExecutionRoleArn: !GetAtt ExecutionRole.Arn
+      TaskRoleArn: !GetAtt TaskRole.Arn
+      ContainerDefinitions:
+        - Name: BottlerocketEcsUpdaterService
+          Image: !Ref UpdaterImage
+          Environment:
+            - Name: BOTTLEROCKET_ECS_CLUSTER
+              Value: !Ref ClusterName
+            - Name: AWS_REGION
+              Value: !Ref AWS::Region
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-region: !Ref AWS::Region
+              awslogs-group: !Ref LogGroupName
+              awslogs-stream-prefix: !Sub '/ecs/bottlerocket-updater/${ClusterName}'
+  BottlerocketUpdaterSchedule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: "Check for Bottlerocket updates on a schedule"
+      # Run Task every 5 minutes
+      ScheduleExpression: "cron(0/5 * * * ? *)"
+      State: 'ENABLED'
+      Targets:
+        - Id: ecs-updater-fargate-task
+          RoleArn: !GetAtt CronRole.Arn
+          Arn: !Sub 'arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}'
+          EcsParameters:
+            LaunchType: FARGATE
+            TaskCount: 1
+            TaskDefinitionArn: !Ref UpdaterTaskDefinition
+            NetworkConfiguration:
+              AwsVpcConfiguration:
+                # The Bottlerocket ECS Updater does not need a public IP for its operations. The public IP
+                # is only required to pull images from ECR as a Fargate task
+                AssignPublicIp: ENABLED
+                Subnets: !Ref Subnets
+  CronRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service:
+                - "events.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+      Path: !Sub '/${AWS::StackName}/'
+      Policies:
+        - PolicyName: "BottlerocketEcsUpdaterSchedulerPolicy"
+          PolicyDocument:
+            Statement:
+              - Effect: "Allow"
+                Condition:
+                  ArnEquals:
+                    ecs:cluster: !Sub 'arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}'
+                Action: "ecs:RunTask"
+                Resource:
+                  - !Ref UpdaterTaskDefinition
+              - Effect: "Allow"
+                Condition:
+                  ArnEquals:
+                    ecs:cluster: !Sub 'arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}'
+                Action:
+                  - "iam:PassRole"
+                Resource:
+                  - !GetAtt TaskRole.Arn
+                  - !GetAtt ExecutionRole.Arn

--- a/updater/Dockerfile
+++ b/updater/Dockerfile
@@ -36,4 +36,5 @@ COPY --from=amazonlinux:2 /etc/ssl /etc/ssl
 COPY --from=amazonlinux:2 /etc/pki /etc/pki
 COPY --from=builder \
     /wrkdir/bottlerocket-ecs-updater \
-    /usr/local/bin/bottlerocket-ecs-updater
+    /bottlerocket-ecs-updater
+ENTRYPOINT ["/bottlerocket-ecs-updater"]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#2


**Description of changes:**
Created a cloudformation stack that starts required resources and sets up Event rule to run fargate task for `bottlerocket-ecs-updater` on a schedule. Stack also adds iam policy to restrict permission of the task.


**Testing done:**
Deployed stack and saw Fargate task getting scheduled at an interval of 5min. Also, checked Cloudwatch logs which shows list of container instances arn in a cluster.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
