### PR TITLE
Fixed a bug `CA certificate not found` while running updater image

### DIFF
--- a/updater/Dockerfile
+++ b/updater/Dockerfile
@@ -22,7 +22,6 @@ ENV CARGO_HOME=/cargo_home
 ENV OUTPUT_DIR=/wrkdir/target/${RUST_TARGET}/release
 COPY ./Cargo.toml ./Cargo.lock ./
 COPY ./src ./src
-
 # mount cache volumes for cargo targets and cargo home, build the updater
 # binary, and copy the binary out of the cache volume
 RUN --mount=type=cache,target=/wrkdir/target,from=buildcache,source=/targetdir \
@@ -32,6 +31,9 @@ RUN --mount=type=cache,target=/wrkdir/target,from=buildcache,source=/targetdir \
 
 # create an image with just the binary
 FROM scratch
+# rusttls requires CA certificates store
+COPY --from=amazonlinux:2 /etc/ssl /etc/ssl
+COPY --from=amazonlinux:2 /etc/pki /etc/pki
 COPY --from=builder \
     /wrkdir/bottlerocket-ecs-updater \
     /usr/local/bin/bottlerocket-ecs-updater


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
updater binrary uses `rustlts` which expects CA certificates in the platform. This change copies CA certificate bundle from `bottlerocker-sdk` to our updater docker image.



**Testing done:**
Launch the updater stack and saw `updater` binary running.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
