### PR TITLE
Fixed CI failure due to `cargo-deny` install failure

### DIFF
--- a/.github/workflows/updater-ci.yaml
+++ b/.github/workflows/updater-ci.yaml
@@ -45,7 +45,7 @@ jobs:
           restore-keys: |
             ${{ hashFiles('.github/cache-bust') }}-
 
-      - run: rustup update stable && cargo install cargo-deny
+      - run: rustup update stable && cargo install cargo-deny --locked
       - run: make ci
 
   image:


### PR DESCRIPTION



<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
cargo install cargo-deny was failing due to issue in downstream dependency `funty` and `bitvec`. cargo-deny issue [#331](https://github.com/EmbarkStudios/cargo-deny/issues/331) This change adds `--locked` to `cargo-deny` install so exact version specified in `Cargo.lock` of `cargo-deny` is used to fetch dependency instead of skipping minor version.


**Testing done:**
Tested command locally and it works.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
