### PR TITLE
Completed check update to get instances to update

### DIFF
--- a/stacks/bottlerocket-ecs-updater.yaml
+++ b/stacks/bottlerocket-ecs-updater.yaml
@@ -66,6 +66,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - 'ssm:ListCommandInvocations'
+                  - 'ssm:GetCommandInvocation'
                 Resource:
                   - !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:*"
   UpdaterTaskDefinition:

--- a/updater/Cargo.lock
+++ b/updater/Cargo.lock
@@ -78,6 +78,7 @@ name = "bottlerocket-ecs-updater"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "chrono",
  "env_logger",
  "log",
  "mock-it",
@@ -86,6 +87,8 @@ dependencies = [
  "rusoto_ecs",
  "rusoto_signature",
  "rusoto_ssm",
+ "serde",
+ "serde_json",
  "snafu",
  "structopt",
  "tokio",
@@ -125,6 +128,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
+ "time 0.1.43",
  "winapi",
 ]
 
@@ -841,7 +845,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "sha2",
- "time",
+ "time 0.2.25",
  "tokio",
 ]
 
@@ -1196,6 +1200,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/updater/Cargo.toml
+++ b/updater/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 async-trait = "0.1"
+chrono = { version = "0.4", features = ["serde"] }
 env_logger = "0.8"
 log = "0.4"
 rusoto_core = { version = "0.46", default-features = false, features = [ "rustls" ] }
@@ -15,6 +16,8 @@ rusoto_credential = "0.46"
 rusoto_ecs = { version = "0.46", default-features = false, features = [ "rustls" ] }
 rusoto_signature = "0.46"
 rusoto_ssm = { version = "0.46", default-features = false, features = [ "rustls" ] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 snafu = "0.6"
 structopt = "0.3"
 tokio = { version = "1", features = ["macros", "process"] }

--- a/updater/src/lib.rs
+++ b/updater/src/lib.rs
@@ -117,15 +117,24 @@ pub struct SsmCommandDetails {
 
 // invocation results from ssm `ListCommandInvocationsResult` will be mapped to this
 #[derive(Debug, Clone, PartialEq)]
-pub struct SsmInvocationResult {
+pub struct SsmInvocationStatus {
     // ec2 instance id on which command ran
     pub instance_id: String,
-    // ssm command script output
-    pub script_output: Option<String>,
     // command invocation status, valid values are Success, Failed, or Pending
     pub invocation_status: String,
+}
+
+// invocation results from ssm `GetCommandInvocationResult` will be mapped to this
+#[derive(Debug, Clone, PartialEq)]
+pub struct SsmInvocationOutput {
+    // ec2 instance id on which command ran
+    pub instance_id: String,
+    // ssm command script output on stdout
+    pub standard_output: String,
+    // command invocation status, valid values are Success, Failed, or Pending
+    pub status: String,
     // command invocation script response code
-    pub script_response_code: Option<i64>,
+    pub response_code: i64,
 }
 
 /// Introducing a trait abstraction over the the SSM API allows us to mock the API and write tests
@@ -141,12 +150,15 @@ pub trait SsmMediator {
         timeout: Option<i64>,
     ) -> Result<SsmCommandDetails>;
 
+    /// Gets the all ssm command status
+    async fn list_command_invocations(&self, command_id: &str) -> Result<Vec<SsmInvocationStatus>>;
+
     /// Gets the ssm command result
-    async fn list_command_invocations(
+    async fn get_command_invocations(
         &self,
         command_id: &str,
-        details: bool,
-    ) -> Result<Vec<SsmInvocationResult>>;
+        instance_id: &str,
+    ) -> Result<SsmInvocationOutput>;
 
     async fn wait_command_complete(&self, command_id: &str) -> Result<()>;
 }

--- a/updater/src/updater.rs
+++ b/updater/src/updater.rs
@@ -1,5 +1,7 @@
-use crate::{Args, EcsMediator, Instance, SsmMediator};
-use snafu::{ResultExt, Snafu};
+use crate::{Args, EcsMediator, Instance, SsmInvocationOutput, SsmMediator};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use snafu::{OptionExt, ResultExt, Snafu};
 use std::collections::HashMap;
 
 // TODO: might need tuning for better default value
@@ -7,6 +9,50 @@ use std::collections::HashMap;
 const BATCH_INSTANCE_COUNT: i64 = 20;
 // time after which ssm command will timeout if not complete
 const SSM_CHECK_COMMAND_TIMEOUT_SECS: i64 = 120;
+
+// Used to deserialize check command output
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+struct UpdateInfo {
+    chosen_update: Option<Update>,
+    update_state: String,
+    available_updates: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+struct Update {
+    arch: String,
+    version: String,
+    variant: String,
+}
+
+// Contains all the information required to update instance and track its status
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub(crate) struct InstanceInfo {
+    instance_id: String,
+    instance_status: String,
+    update_version: String,
+    current_state: InstanceState,
+    next_state: InstanceState,
+    start_time: Option<DateTime<Utc>>,
+    status: UpdateStepStatus,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum InstanceState {
+    UpdateAvailable,
+    Drain,
+    Update,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum UpdateStepStatus {
+    NotStarted,
+    Running,
+    Success,
+    Failed,
+}
 
 /// The long-lived object that will watch an ECS cluster and update Bottlerocket hosts.
 pub struct Updater<T: EcsMediator, S: SsmMediator> {
@@ -37,10 +83,11 @@ impl<T: EcsMediator, S: SsmMediator> Updater<T, S> {
         Ok(())
     }
 
-    // Iterates cluster instances in batch and returns all instances with updates available
-    pub(crate) async fn update_available(&self) -> Result<Vec<String>> {
+    // Iterates cluster instances in batch and returns instances with updates available
+    pub(crate) async fn update_available(&self) -> Result<Vec<InstanceInfo>> {
         // contains token to fetch next set of instances, set to None for 1st batch
         let mut next_token: Option<String> = None;
+        let mut instances_to_update: Vec<InstanceInfo> = Vec::new();
         loop {
             // get Bottlerocket instances
             let instances = self
@@ -55,11 +102,12 @@ impl<T: EcsMediator, S: SsmMediator> Updater<T, S> {
             dbg!(instances.clone());
 
             // send ssm command to check updates
+            let instance_ids = get_instance_ids(&instances.bottlerocket_instances);
             let params = check_updates_param();
             let ssm_command_details = self
                 .ssm
                 .send_command(
-                    get_instance_ids(&instances.bottlerocket_instances),
+                    instance_ids.clone(),
                     params,
                     Some(SSM_CHECK_COMMAND_TIMEOUT_SECS),
                 )
@@ -72,24 +120,32 @@ impl<T: EcsMediator, S: SsmMediator> Updater<T, S> {
                     command_id: ssm_command_details.command_id.clone(),
                 })?;
 
-            // get command result
-            let _result = self
-                .ssm
-                .list_command_invocations(&ssm_command_details.command_id, true)
-                .await
-                .context(CheckUpdateCommandOutput {
-                    command_id: &ssm_command_details.command_id,
-                })?;
-
-            // TODO parse command output and filter instances with available updates
+            // iterate instances to get command result and collect instances with available updates
+            for instance_id in instance_ids {
+                let invocation_result = self
+                    .ssm
+                    .get_command_invocations(&ssm_command_details.command_id, &instance_id)
+                    .await
+                    .context(CheckUpdateCommandOutput {
+                        command_id: ssm_command_details.command_id.clone(),
+                        instance_id: instance_id.clone(),
+                    });
+                match invocation_result {
+                    Ok(output) => {
+                        add_if_update_available(&mut instances_to_update, &instance_id, &output)?;
+                    }
+                    Err(e) => {
+                        println!("Error '{}' is not fatal, Ignore instance it will be checked in next iteration!", e)
+                    }
+                }
+            }
             match instances.next_token {
                 // Exit the loop if there are no more instances to check
                 None => break,
                 Some(token) => next_token = Some(token),
             };
         }
-        // TODO: return instances information with available updates
-        Ok(Vec::new())
+        Ok(instances_to_update)
     }
 }
 
@@ -113,13 +169,81 @@ fn check_updates_param() -> HashMap<String, Vec<String>> {
     params
 }
 
+// Adds instance `InstanceInfo` to list if it has update available
+fn add_if_update_available(
+    list: &mut Vec<InstanceInfo>,
+    instance_id: &str,
+    command_output: &SsmInvocationOutput,
+) -> Result<bool> {
+    // script should execute successfully
+    if command_output.response_code == 0 {
+        let update_info = parse_update_status(&command_output.standard_output)?;
+        dbg!(update_info.clone());
+        // check if update is available
+        if update_info.update_state == "Available" {
+            list.push(create_instance_info(
+                instance_id,
+                &command_output.status,
+                &update_info,
+            )?);
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+// Deserializes check update command output
+fn parse_update_status(api_output: &str) -> Result<UpdateInfo> {
+    Ok(serde_json::from_str(api_output).context(CheckUpdateJson)?)
+}
+
+// Creates `InstanceInfo`
+fn create_instance_info(
+    instance_id: &str,
+    instance_status: &str,
+    update_info: &UpdateInfo,
+) -> Result<InstanceInfo> {
+    Ok(InstanceInfo {
+        instance_id: instance_id.to_string(),
+        instance_status: instance_status.to_string(),
+        update_version: update_info
+            .chosen_update
+            .as_ref()
+            .context(self::EmptyChosenUpdate { instance_id })?
+            .version
+            .clone(),
+        current_state: InstanceState::UpdateAvailable,
+        next_state: InstanceState::Drain,
+        start_time: None,
+        status: UpdateStepStatus::NotStarted,
+    })
+}
+
 type Result<T> = std::result::Result<T, Error>;
 
 /// The error type for this module.
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Failed to list cluster instances to check for updates: {}", source))]
-    ListInstances { source: crate::Error },
+    #[snafu(display("Failed to send check update command: {}", source))]
+    CheckUpdateCommand { source: crate::Error },
+
+    #[snafu(display(
+        "Failed to get check update command output for command id {} and instance {}: {}",
+        command_id,
+        instance_id,
+        source
+    ))]
+    CheckUpdateCommandOutput {
+        command_id: String,
+        instance_id: String,
+        source: crate::Error,
+    },
+
+    #[snafu(display("Failed to parse check update command output json: {}", source))]
+    CheckUpdateJson { source: serde_json::Error },
+
+    #[snafu(display("Failed to get check update command status: {}", source))]
+    CommandInvocationStatus { source: crate::Error },
 
     #[snafu(display(
         "Failed to describe cluster instances to check for updates: {}",
@@ -127,18 +251,14 @@ pub enum Error {
     ))]
     DescribeInstances { source: crate::Error },
 
-    #[snafu(display("Failed to send check update command: {}", source))]
-    CheckUpdateCommand { source: crate::Error },
-
     #[snafu(display(
-        "Failed to get check update command output for command id {}: {}",
-        command_id,
-        source
+        "Update is available but chosen update is missing for instance {}",
+        instance_id
     ))]
-    CheckUpdateCommandOutput {
-        command_id: String,
-        source: crate::Error,
-    },
+    EmptyChosenUpdate { instance_id: String },
+
+    #[snafu(display("Failed to list cluster instances to check for updates: {}", source))]
+    ListInstances { source: crate::Error },
 
     #[snafu(display(
         "Failed to wait for ssm check update command with command_id {} to complete: {}",


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#5 


**Description of changes:**
Added ssm api call to get command output, parsed output to check if update available and collected list of instance info to
update.


**Testing done:**
1. Ran locally and saw command output logs and instances with update available being logged.
2. Deployed image and verified `cloudwatch` logs to contain command output logs and instances with update available being logged. 


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
