### PR TITLE
Add SSM SendCommand and GetCommandInvocation

### DIFF
--- a/updater/aws.go
+++ b/updater/aws.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go/service/ssm"
+)
+
+const (
+	pageSize = 50
+)
+
+func listContainerInstances(ecsClient *ecs.ECS, cluster string, pageSize int64) ([]*string, error) {
+	resp, err := ecsClient.ListContainerInstances(&ecs.ListContainerInstancesInput{
+		Cluster: &cluster,
+		MaxResults: aws.Int64(pageSize),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot list container instances: %#v", err)
+	}
+	log.Printf("%#v", resp)
+	return resp.ContainerInstanceArns, nil
+}
+
+func filterBottlerocketInstances(ecsClient *ecs.ECS, cluster string, instances []*string) ([]*string, error) {
+	resp, err := ecsClient.DescribeContainerInstances(&ecs.DescribeContainerInstancesInput{
+		Cluster: &cluster, ContainerInstances: instances,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot describe container instances: %#v", err)
+	}
+
+	log.Printf("Container descriptions: %#v", resp)
+
+	ec2IDs := make([]*string, 0)
+	// Check the DescribeInstances response for Bottlerocket container instances, add them to ec2ids if detected
+	for _, instance := range resp.ContainerInstances {
+		if containsAttribute(instance.Attributes, "bottlerocket.variant") {
+			ec2IDs = append(ec2IDs, instance.Ec2InstanceId)
+			log.Printf("Bottlerocket instance detected. Instance %#v added to check updates", *instance.Ec2InstanceId)
+		}
+	}
+	return ec2IDs, nil
+}
+
+// checks if ECS Attributes struct contains a specified string
+func containsAttribute(attrs []*ecs.Attribute, searchString string) bool {
+	for _, attr := range attrs {
+		if aws.StringValue(attr.Name) == searchString {
+			return true
+		}
+	}
+	return false
+}
+
+func sendCommand(ssmClient *ssm.SSM, instanceIDs []*string, ssmCommand string) (string, error) {
+	log.Printf("Checking InstanceIDs: %#v", instanceIDs)
+
+	resp, err := ssmClient.SendCommand(&ssm.SendCommandInput{
+		DocumentName:    aws.String("AWS-RunShellScript"),
+		DocumentVersion: aws.String("$DEFAULT"),
+		InstanceIds:     instanceIDs,
+		Parameters: map[string][]*string{
+			"commands": {aws.String(ssmCommand)},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("command invocation failed: %#v", err)
+	}
+
+	commandID := *resp.Command.CommandId
+	// Wait for the sent commands to complete
+	// TODO Update this to use WaitGroups
+	for _, v := range instanceIDs {
+		ssmClient.WaitUntilCommandExecuted(&ssm.GetCommandInvocationInput{
+			CommandId:  &commandID,
+			InstanceId: v,
+		})
+	}
+	log.Printf("CommandID: %#v", commandID)
+	return commandID, nil
+}
+
+func checkCommandOutput(ssmClient *ssm.SSM, commandID string, instanceIDs []*string) ([]string, error) {
+	updateCandidates := make([]string, 0)
+	for _, v := range instanceIDs {
+		resp, err := ssmClient.GetCommandInvocation(&ssm.GetCommandInvocationInput{
+			CommandId:  aws.String(commandID),
+			InstanceId: v,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to retreive command invocation output: %#v", err)
+		}
+
+		type updateCheckResult struct {
+			UpdateState string `json:"update_state"`
+		}
+
+		var result updateCheckResult
+		err = json.Unmarshal([]byte(*resp.StandardOutputContent), &result)
+		if err != nil {
+			log.Printf("failed to unmarshal command invocation output: %#v", err)
+		}
+		log.Println("update_state: ", result)
+
+		switch result.UpdateState {
+		case "Available":
+			updateCandidates = append(updateCandidates, *v)
+		}
+	}
+
+	if updateCandidates == nil {
+		log.Printf("No instances to update")
+	}
+	return updateCandidates, nil
+}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Addresses https://github.com/bottlerocket-os/bottlerocket-ecs-updater/issues/5


**Description of changes:**
Adds SSM functionality which sends SSM commands to Bottlerocket instances in the ECS cluster to query update status. Commands output is then checked to verify if updates are available. Additionally, code specific to AWS is split into its own file. 


**Testing done:**
Execution of changes with 2 Bottlerocket ECS instances at version 1.0.5 (output truncated for brevity): 

```
...
2021/04/02 09:30:03 DEBUG: Response ssm/GetCommandInvocation Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 200 OK
Connection: keep-alive
Content-Type: application/x-amz-json-1.1
Date: Fri, 02 Apr 2021 16:30:03 GMT
Server: Server
X-Amzn-Requestid: faca85a7-9fbb-45ba-8b23-f2674dd40610


-----------------------------------------------------
2021/04/02 09:30:03 {"CloudWatchOutputConfig":{"CloudWatchLogGroupName":"","CloudWatchOutputEnabled":false},"CommandId":"1021c0a4-5925-44fc-a2f0-eac301c63976","Comment":"","DocumentName":"AWS-RunShellScript","DocumentVersion":"$DEFAULT","ExecutionElapsedTime":"PT0.417S","ExecutionEndDateTime":"2021-04-02T16:29:58.080Z","ExecutionStartDateTime":"2021-04-02T16:29:58.080Z","InstanceId":"i-0f9aa7fabb1de8350","PluginName":"aws:runShellScript","ResponseCode":0,"StandardErrorContent":"16:29:58 \u001B[0m\u001B[34m[INFO] \u001B[0mRefreshing updates...\n","StandardErrorUrl":"","StandardOutputContent":"{\n  \"active_partition\": {\n    \"image\": {\n      \"arch\": \"x86_64\",\n      \"variant\": \"aws-ecs-1\",\n      \"version\": \"1.0.5\"\n    },\n    \"next_to_boot\": true\n  },\n  \"available_updates\": [\n    \"1.0.7\",\n    \"1.0.6\",\n    \"1.0.5\",\n    \"1.0.4\",\n    \"1.0.3\",\n    \"1.0.2\",\n    \"1.0.1\",\n    \"1.0.0\"\n  ],\n  \"chosen_update\": {\n    \"arch\": \"x86_64\",\n    \"variant\": \"aws-ecs-1\",\n    \"version\": \"1.0.7\"\n  },\n  \"most_recent_command\": {\n    \"cmd_status\": \"Success\",\n    \"cmd_type\": \"refresh\",\n    \"exit_status\": 0,\n    \"stderr\": \"\",\n    \"timestamp\": \"2021-04-02T16:29:58.395004687Z\"\n  },\n  \"staging_partition\": null,\n  \"update_state\": \"Available\"\n}\n","StandardOutputUrl":"","Status":"Success","StatusDetails":"Success"}
Instances ready for update:  [i-048f01d65c344a5c7 i-0f9aa7fabb1de8350]
```

One of the Bottlerocket instances, `i-048f01d65c344a5c7`, was then updated to 1.0.7 and execution retested to confirm instances running the current release do not get added to the update list:

```
2021/04/05 12:25:27 DEBUG: Response ssm/GetCommandInvocation Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 200 OK
Connection: keep-alive
Content-Type: application/x-amz-json-1.1
Date: Mon, 05 Apr 2021 19:25:27 GMT
Server: Server
X-Amzn-Requestid: 6b950ac6-5d5d-4be1-aa11-394671ae2410


-----------------------------------------------------
2021/04/05 12:25:27 {"CloudWatchOutputConfig":{"CloudWatchLogGroupName":"","CloudWatchOutputEnabled":false},"CommandId":"337a46d2-e814-4154-98af-13dbd24d37c6","Comment":"","DocumentName":"AWS-RunShellScript","DocumentVersion":"$DEFAULT","ExecutionElapsedTime":"PT0.417S","ExecutionEndDateTime":"2021-04-05T19:25:22.550Z","ExecutionStartDateTime":"2021-04-05T19:25:22.550Z","InstanceId":"i-0f9aa7fabb1de8350","PluginName":"aws:runShellScript","ResponseCode":0,"StandardErrorContent":"19:25:22 \u001B[0m\u001B[34m[INFO] \u001B[0mRefreshing updates...\n","StandardErrorUrl":"","StandardOutputContent":"{\n  \"active_partition\": {\n    \"image\": {\n      \"arch\": \"x86_64\",\n      \"variant\": \"aws-ecs-1\",\n      \"version\": \"1.0.5\"\n    },\n    \"next_to_boot\": true\n  },\n  \"available_updates\": [\n    \"1.0.7\",\n    \"1.0.6\",\n    \"1.0.5\",\n    \"1.0.4\",\n    \"1.0.3\",\n    \"1.0.2\",\n    \"1.0.1\",\n    \"1.0.0\"\n  ],\n  \"chosen_update\": {\n    \"arch\": \"x86_64\",\n    \"variant\": \"aws-ecs-1\",\n    \"version\": \"1.0.7\"\n  },\n  \"most_recent_command\": {\n    \"cmd_status\": \"Success\",\n    \"cmd_type\": \"refresh\",\n    \"exit_status\": 0,\n    \"stderr\": \"\",\n    \"timestamp\": \"2021-04-05T19:25:22.932412959Z\"\n  },\n  \"staging_partition\": null,\n  \"update_state\": \"Available\"\n}\n","StandardOutputUrl":"","Status":"Success","StatusDetails":"Success"}
2021/04/05 12:25:27 update_state:  {Available}
Instances ready for update:  [i-0f9aa7fabb1de8350]
``` 

An AL2 ECS node, instance ID `i-06662b978baaded15`, was also added alongside the 1.0.5 and 1.0.7 Bottlerocket instances to the test cluster to ensure non Bottlerocket nodes do not get added to the list to update: 

```
2021/04/05 12:30:16 DEBUG: Response ssm/GetCommandInvocation Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 200 OK
Connection: keep-alive
Content-Type: application/x-amz-json-1.1
Date: Mon, 05 Apr 2021 19:30:16 GMT
Server: Server
X-Amzn-Requestid: 8603d955-0a09-478c-9065-6a57fbdbafb9


-----------------------------------------------------
2021/04/05 12:30:16 {"CloudWatchOutputConfig":{"CloudWatchLogGroupName":"","CloudWatchOutputEnabled":false},"CommandId":"81fd9610-cfca-4ee4-807a-847042fe7456","Comment":"","DocumentName":"AWS-RunShellScript","DocumentVersion":"$DEFAULT","ExecutionElapsedTime":"PT0.315S","ExecutionEndDateTime":"2021-04-05T19:30:12.071Z","ExecutionStartDateTime":"2021-04-05T19:30:12.071Z","InstanceId":"i-0f9aa7fabb1de8350","PluginName":"aws:runShellScript","ResponseCode":0,"StandardErrorContent":"19:30:12 \u001B[0m\u001B[34m[INFO] \u001B[0mRefreshing updates...\n","StandardErrorUrl":"","StandardOutputContent":"{\n  \"active_partition\": {\n    \"image\": {\n      \"arch\": \"x86_64\",\n      \"variant\": \"aws-ecs-1\",\n      \"version\": \"1.0.5\"\n    },\n    \"next_to_boot\": true\n  },\n  \"available_updates\": [\n    \"1.0.7\",\n    \"1.0.6\",\n    \"1.0.5\",\n    \"1.0.4\",\n    \"1.0.3\",\n    \"1.0.2\",\n    \"1.0.1\",\n    \"1.0.0\"\n  ],\n  \"chosen_update\": {\n    \"arch\": \"x86_64\",\n    \"variant\": \"aws-ecs-1\",\n    \"version\": \"1.0.7\"\n  },\n  \"most_recent_command\": {\n    \"cmd_status\": \"Success\",\n    \"cmd_type\": \"refresh\",\n    \"exit_status\": 0,\n    \"stderr\": \"\",\n    \"timestamp\": \"2021-04-05T19:30:12.360535115Z\"\n  },\n  \"staging_partition\": null,\n  \"update_state\": \"Available\"\n}\n","StandardOutputUrl":"","Status":"Success","StatusDetails":"Success"}
2021/04/05 12:30:16 update_state:  {Available}
Instances ready for update:  [i-0f9aa7fabb1de8350]
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
