### PR TITLE
Drain instances

### DIFF
--- a/updater/aws.go
+++ b/updater/aws.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
@@ -14,9 +16,9 @@ const (
 	pageSize = 50
 )
 
-func listContainerInstances(ecsClient *ecs.ECS, cluster string, pageSize int64) ([]*string, error) {
-	resp, err := ecsClient.ListContainerInstances(&ecs.ListContainerInstancesInput{
-		Cluster: &cluster,
+func (u *updater) listContainerInstances() ([]*string, error) {
+	resp, err := u.ecs.ListContainerInstances(&ecs.ListContainerInstancesInput{
+		Cluster:    &u.cluster,
 		MaxResults: aws.Int64(pageSize),
 	})
 	if err != nil {
@@ -26,28 +28,29 @@ func listContainerInstances(ecsClient *ecs.ECS, cluster string, pageSize int64) 
 	return resp.ContainerInstanceArns, nil
 }
 
-func filterBottlerocketInstances(ecsClient *ecs.ECS, cluster string, instances []*string) ([]*string, error) {
-	resp, err := ecsClient.DescribeContainerInstances(&ecs.DescribeContainerInstancesInput{
-		Cluster: &cluster, ContainerInstances: instances,
+// filterBottlerocketInstances returns a map of EC2 instance IDs to container instance ARNs
+// provided as input where the container instance is a Bottlerocket host.
+func (u *updater) filterBottlerocketInstances(instances []*string) (map[string]string, error) {
+	resp, err := u.ecs.DescribeContainerInstances(&ecs.DescribeContainerInstancesInput{
+		Cluster:            &u.cluster,
+		ContainerInstances: instances,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("cannot describe container instances: %#v", err)
 	}
 
-	log.Printf("Container descriptions: %#v", resp)
-
-	ec2IDs := make([]*string, 0)
-	// Check the DescribeInstances response for Bottlerocket container instances, add them to ec2ids if detected
+	ec2IDtoECSARN := make(map[string]string)
+	// Check the DescribeInstances response for Bottlerocket nodes, add them to map if detected.
 	for _, instance := range resp.ContainerInstances {
 		if containsAttribute(instance.Attributes, "bottlerocket.variant") {
-			ec2IDs = append(ec2IDs, instance.Ec2InstanceId)
-			log.Printf("Bottlerocket instance detected. Instance %#v added to check updates", *instance.Ec2InstanceId)
+			ec2IDtoECSARN[aws.StringValue(instance.Ec2InstanceId)] = aws.StringValue(instance.ContainerInstanceArn)
+			log.Printf("Bottlerocket instance detected. Instance %s added to check updates", aws.StringValue(instance.Ec2InstanceId))
 		}
 	}
-	return ec2IDs, nil
+	return ec2IDtoECSARN, nil
 }
 
-// checks if ECS Attributes struct contains a specified string
+// containsAttribute checks if a slice of ECS Attributes struct contains a specified name.
 func containsAttribute(attrs []*ecs.Attribute, searchString string) bool {
 	for _, attr := range attrs {
 		if aws.StringValue(attr.Name) == searchString {
@@ -57,13 +60,125 @@ func containsAttribute(attrs []*ecs.Attribute, searchString string) bool {
 	return false
 }
 
-func sendCommand(ssmClient *ssm.SSM, instanceIDs []*string, ssmCommand string) (string, error) {
-	log.Printf("Checking InstanceIDs: %#v", instanceIDs)
+// drain drains eligible container instances. Container instances are eligible if all running
+// tasks were started by a service, or if there are no running tasks.
+func (u *updater) drain(containerInstance string) error {
+	if !u.eligible(&containerInstance) {
+		return errors.New("ineligible for updates")
+	}
+	return u.drainInstance(aws.String(containerInstance))
+}
 
-	resp, err := ssmClient.SendCommand(&ssm.SendCommandInput{
+func (u *updater) eligible(containerInstance *string) bool {
+	list, err := u.ecs.ListTasks(&ecs.ListTasksInput{
+		Cluster:           &u.cluster,
+		ContainerInstance: containerInstance,
+	})
+	if err != nil {
+		log.Printf("failed to list tasks for container instance %s: %#v",
+			aws.StringValue(containerInstance), err)
+		return false
+	}
+
+	taskARNs := list.TaskArns
+	if len(list.TaskArns) == 0 {
+		return true
+	}
+
+	desc, err := u.ecs.DescribeTasks(&ecs.DescribeTasksInput{
+		Cluster: &u.cluster,
+		Tasks:   taskARNs,
+	})
+	if err != nil {
+		log.Printf("Could not describe tasks")
+		return false
+	}
+
+	for _, listResult := range desc.Tasks {
+		startedBy := aws.StringValue(listResult.StartedBy)
+		if !strings.HasPrefix(startedBy, "ecs-svc/") {
+			return false
+		}
+	}
+	return true
+}
+
+func (u *updater) drainInstance(containerInstance *string) error {
+	resp, err := u.ecs.UpdateContainerInstancesState(&ecs.UpdateContainerInstancesStateInput{
+		Cluster:            &u.cluster,
+		ContainerInstances: []*string{containerInstance},
+		Status:             aws.String("DRAINING"),
+	})
+	if err != nil {
+		log.Printf("failed to update container instance %s state to DRAINING: %#v", aws.StringValue(containerInstance), err)
+		return err
+	}
+	if len(resp.Failures) != 0 {
+		err = u.activateInstance(containerInstance)
+		if err != nil {
+			log.Printf("instance failed to reactivate after failing to drain: %#v", err)
+		}
+		return fmt.Errorf("Container instance %s failed to drain: %#v", aws.StringValue(containerInstance), resp.Failures)
+	}
+	log.Printf("Container instance state changed to DRAINING")
+
+	err = u.waitUntilDrained(aws.StringValue(containerInstance))
+	if err != nil {
+		err2 := u.activateInstance(containerInstance)
+		if err2 != nil {
+			log.Printf("failed to reactivate %s: %s", aws.StringValue(containerInstance), err2.Error())
+		}
+		return err
+	}
+	return nil
+}
+
+func (u *updater) activateInstance(containerInstance *string) error {
+	resp, err := u.ecs.UpdateContainerInstancesState(&ecs.UpdateContainerInstancesStateInput{
+		Cluster:            &u.cluster,
+		ContainerInstances: []*string{containerInstance},
+		Status:             aws.String("ACTIVE"),
+	})
+	if err != nil {
+		log.Printf("failed to update container %s instance state to ACTIVE: %#v", aws.StringValue(containerInstance), err)
+		return err
+	}
+	if len(resp.Failures) != 0 {
+		return fmt.Errorf("Container instance %s failed to activate: %#v", aws.StringValue(containerInstance), resp.Failures)
+	}
+	log.Printf("Container instance state changed to ACTIVE")
+	return nil
+}
+
+func (u *updater) waitUntilDrained(containerInstance string) error {
+	list, err := u.ecs.ListTasks(&ecs.ListTasksInput{
+		Cluster:           &u.cluster,
+		ContainerInstance: aws.String(containerInstance),
+	})
+	if err != nil {
+		log.Printf("failed to identify a task to wait on")
+		return err
+	}
+
+	taskARNs := list.TaskArns
+
+	if len(taskARNs) == 0 {
+		return nil
+	}
+	// TODO Tune MaxAttempts
+	return u.ecs.WaitUntilTasksStopped(&ecs.DescribeTasksInput{
+		Cluster: &u.cluster,
+		Tasks:   taskARNs,
+	})
+}
+
+func (u *updater) sendCommand(instanceIDs []string, ssmCommand string) (string, error) {
+	log.Printf("Checking InstanceIDs: %q", instanceIDs)
+
+	resp, err := u.ssm.SendCommand(&ssm.SendCommandInput{
 		DocumentName:    aws.String("AWS-RunShellScript"),
 		DocumentVersion: aws.String("$DEFAULT"),
-		InstanceIds:     instanceIDs,
+		InstanceIds:     aws.StringSlice(instanceIDs),
 		Parameters: map[string][]*string{
 			"commands": {aws.String(ssmCommand)},
 		},
@@ -73,24 +188,24 @@ func sendCommand(ssmClient *ssm.SSM, instanceIDs []*string, ssmCommand string) (
 	}
 
 	commandID := *resp.Command.CommandId
-	// Wait for the sent commands to complete
+	// Wait for the sent commands to complete.
 	// TODO Update this to use WaitGroups
 	for _, v := range instanceIDs {
-		ssmClient.WaitUntilCommandExecuted(&ssm.GetCommandInvocationInput{
+		u.ssm.WaitUntilCommandExecuted(&ssm.GetCommandInvocationInput{
 			CommandId:  &commandID,
-			InstanceId: v,
+			InstanceId: &v,
 		})
 	}
-	log.Printf("CommandID: %#v", commandID)
+	log.Printf("CommandID: %s", commandID)
 	return commandID, nil
 }
 
-func checkCommandOutput(ssmClient *ssm.SSM, commandID string, instanceIDs []*string) ([]string, error) {
+func (u *updater) checkSSMCommandOutput(commandID string, instanceIDs []string) ([]string, error) {
 	updateCandidates := make([]string, 0)
 	for _, v := range instanceIDs {
-		resp, err := ssmClient.GetCommandInvocation(&ssm.GetCommandInvocationInput{
+		resp, err := u.ssm.GetCommandInvocation(&ssm.GetCommandInvocationInput{
 			CommandId:  aws.String(commandID),
-			InstanceId: v,
+			InstanceId: aws.String(v),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to retreive command invocation output: %#v", err)
@@ -109,12 +224,13 @@ func checkCommandOutput(ssmClient *ssm.SSM, commandID string, instanceIDs []*str
 
 		switch result.UpdateState {
 		case "Available":
-			updateCandidates = append(updateCandidates, *v)
+			updateCandidates = append(updateCandidates, v)
 		}
 	}
 
-	if updateCandidates == nil {
+	if len(updateCandidates) == 0 {
 		log.Printf("No instances to update")
+		return nil, nil
 	}
 	return updateCandidates, nil
 }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Part of [#8](https://github.com/bottlerocket-os/bottlerocket-ecs-updater/issues/8)


**Description of changes:**
Adds functionality to list running tasks on target container instances. Listed tasks are then filtered to ensure that no non-service tasks are drained. The filtered tasks along with container instances with no tasks are passed to drain operations where their state is change from "ACTIVE" to "DRAINING" in preparation for update operations.  


**Testing done:**
I executed the changes against an ECS test cluster containing two Bottlerocket 1.0.5 instances and one AL2 instance under a variety of scenarios: 

Execution output (truncated for brevity. "..." indicates verbose debug output removed):

```
2021/04/09 09:54:43 DEBUG: Response ecs/UpdateContainerInstancesState Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 200
Content-Length: 3927
Content-Type: application/x-amz-json-1.1
Date: Fri, 09 Apr 2021 16:54:43 GMT
X-Amzn-Requestid: f4dfca70-9977-4823-905a-775272098ac1


-----------------------------------------------------
...
2021/04/09 09:54:43 Container instance state changed to DRAINING
```

Bottlerocket container instances: 

* da50864e23154b11add9bbc215c86ce4
* 78daf1f1f1824d6c939380b1521a12e2

AL2 container instnace:

* bee04a804c7e4737af889ce142a13a89

Scenario 1: 

da50864e23154b11add9bbc215c86ce4: 
* 1 Non service task running
* 3 Service tasks running

78daf1f1f1824d6c939380b1521a12e2:
* 0 tasks running

Result: 
```
$ aws ecs describe-container-instances --cluster updater-test-cluster \
--container-instances \
--container-instance da50864e23154b11add9bbc215c86ce4 | grep status
            "status": "ACTIVE",

$ aws ecs describe-container-instances --cluster updater-test-cluster \
--container-instances \
--container-instance 78daf1f1f1824d6c939380b1521a12e2 | grep status
            "status": "DRAINING",

$ aws ecs describe-container-instances --cluster updater-test-cluster \
--container-instances \
--container-instance bee04a804c7e4737af889ce142a13a89 | grep status
            "status": "ACTIVE",
```

Scenario 2: 

da50864e23154b11add9bbc215c86ce4:
* 3 Service tasks running

78daf1f1f1824d6c939380b1521a12e2:
* 0 tasks running

Result:
```
$ aws ecs describe-container-instances --cluster updater-test-cluster \
--container-instances \
--container-instance da50864e23154b11add9bbc215c86ce4 | grep status
            "status": "DRAINING",

$ aws ecs describe-container-instances --cluster updater-test-cluster \
--container-instances \
--container-instance 78daf1f1f1824d6c939380b1521a12e2 | grep status
            "status": "DRAINING",

$ aws ecs describe-container-instances --cluster updater-test-cluster \
--container-instances \
--container-instance bee04a804c7e4737af889ce142a13a89 | grep status
            "status": "ACTIVE",
```

Scenario 3: 

da50864e23154b11add9bbc215c86ce4:
* 3 Service tasks running

78daf1f1f1824d6c939380b1521a12e2:
* 3 Service tasks running

```
$ aws ecs describe-container-instances --cluster updater-test-cluster \
--container-instances \
--container-instance da50864e23154b11add9bbc215c86ce4 | grep status
            "status": "DRAINING",

$ aws ecs describe-container-instances --cluster updater-test-cluster \
--container-instances \
--container-instance 78daf1f1f1824d6c939380b1521a12e2 | grep status
            "status": "DRAINING",

$ aws ecs describe-container-instances --cluster updater-test-cluster \
--container-instances \
--container-instance bee04a804c7e4737af889ce142a13a89 | grep status
            "status": "ACTIVE",
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
