### PR TITLE
Add instance update and reactivation

### DIFF
--- a/updater/main.go
+++ b/updater/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/ssm"
 )
@@ -22,6 +23,7 @@ type updater struct {
 	cluster string
 	ecs     ECSAPI
 	ssm     *ssm.SSM
+	ec2     *ec2.EC2
 }
 
 func main() {
@@ -50,6 +52,7 @@ func _main() error {
 		cluster: *flagCluster,
 		ecs:     ecs.New(sess, aws.NewConfig().WithLogLevel(aws.LogDebugWithHTTPBody)),
 		ssm:     ssm.New(sess, aws.NewConfig().WithLogLevel(aws.LogDebugWithHTTPBody)),
+		ec2:     ec2.New(sess, aws.NewConfig().WithLogLevel(aws.LogDebugWithHTTPBody)),
 	}
 
 	listedInstances, err := u.listContainerInstances()
@@ -78,16 +81,27 @@ func _main() error {
 		return err
 	}
 
-	candidates, err := u.checkSSMCommandOutput(commandID, instances)
-	if err != nil {
-		return err
-	}
+	candidates := make([]string, 0)
+	for _, ec2ID := range instances {
+		commandOutput, err := u.getCommandResult(commandID, ec2ID)
+		if err != nil {
+			return err
+		}
 
+		updateState, err := isUpdateAvailable(commandOutput)
+		if err != nil {
+			return err
+		}
+
+		if updateState {
+			candidates = append(candidates, ec2ID)
+		}
+	}
 	if len(candidates) == 0 {
 		log.Printf("No instances to update")
 		return nil
 	}
-	fmt.Println("Instances ready for update: ", candidates)
+	log.Print("Instances ready for update: ", candidates)
 
 	for ec2ID, containerInstance := range ec2IDtoECSARN {
 		err := u.drain(containerInstance)
@@ -96,6 +110,66 @@ func _main() error {
 			continue
 		}
 		log.Printf("Instance %s drained", ec2ID)
+
+		ec2IDs := []string{ec2ID}
+		_, err = u.sendCommand(ec2IDs, "apiclient update apply --reboot")
+		if err != nil {
+			// TODO add nuanced error checking to determine the type of failure, act accordingly.
+			log.Printf("%#v", err)
+			err2 := u.activateInstance(aws.String(containerInstance))
+			if err2 != nil {
+				log.Printf("failed to reactivate %s after failure to execute update command. Aborting update operations.", ec2ID)
+				return err2
+			}
+			continue
+		}
+
+		err = u.waitUntilOk(ec2ID)
+		if err != nil {
+			return fmt.Errorf("instance %s failed to enter an Ok status after reboot. Aborting update operations: %#v", ec2ID, err)
+		}
+
+		err = u.activateInstance(aws.String(containerInstance))
+		if err != nil {
+			log.Printf("instance %s failed to return to ACTIVE after reboot. Aborting update operations.", ec2ID)
+			return err
+		}
+
+		updateStatus, err := u.sendCommand(ec2IDs, "apiclient update check")
+		if err != nil {
+			log.Printf("%#v", err)
+			continue
+		}
+
+		updateResult, err := u.getCommandResult(updateStatus, ec2ID)
+		if err != nil {
+			log.Printf("%#v", err)
+			continue
+		}
+
+		// TODO  version before and after comparison.
+		updateState, err := isUpdateAvailable(updateResult)
+		if err != nil {
+			log.Printf("Unable to determine update result. Manual verification of %s required", ec2ID)
+			continue
+		}
+
+		if updateState {
+			log.Printf("Instance %s did not update. Manual update advised.", ec2ID)
+			continue
+		} else {
+			log.Printf("Instance %s updated successfully", ec2ID)
+		}
+
+		updatedVersion, err := getActiveVersion(updateResult)
+		if err != nil {
+			log.Printf("%#v", err)
+		}
+		if len(updatedVersion) != 0 {
+			log.Printf("Instance %s running Bottlerocket: %s", ec2ID, updatedVersion)
+		} else {
+			log.Printf("Unable to verify active version. Manual verification of %s required.", ec2ID)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Addresses #9 


**Description of changes:**
Adds functionality to update drained Bottlerocket instances, reboot updated instances and change state to "ACTIVE" after successful upgrade. 


**Testing done:**
Executed changes against ECS test cluster containing a mix of AL2 instances and 4 Bottlerocket version 1.0.5 hosts with service and non-service tasks present in the cluster: 

Output (truncated for brevity):
```
---[ RESPONSE ]--------------------------------------
HTTP/1.1 200 OK
Connection: keep-alive
Content-Type: application/x-amz-json-1.1
Date: Thu, 15 Apr 2021 16:48:30 GMT
Server: Server
X-Amzn-Requestid: c3f71a22-c586-4c1f-b62b-d9724aefd926


-----------------------------------------------------
2021/04/15 09:48:30 {"CloudWatchOutputConfig":{"CloudWatchLogGroupName":"","CloudWatchOutputEnabled":false},"CommandId":"8865c81a-83ae-4c2e-958d-05dc107ef47e","Comment":"","DocumentName":"AWS-RunShellScript","DocumentVersion":"$DEFAULT","ExecutionElapsedTime":"PT0.484S","ExecutionEndDateTime":"2021-04-15T16:48:25.429Z","ExecutionStartDateTime":"2021-04-15T16:48:25.429Z","InstanceId":"i-##########","PluginName":"aws:runShellScript","ResponseCode":0,"StandardErrorContent":"16:48:25 \u001B[0m\u001B[34m[INFO] \u001B[0mRefreshing updates...\n","StandardErrorUrl":"","StandardOutputContent":"{\n  \"active_partition\": {\n    \"image\": {\n      \"arch\": \"x86_64\",\n      \"variant\": \"aws-ecs-1\",\n      \"version\": \"1.0.7\"\n    },\n    \"next_to_boot\": true\n  },\n  \"available_updates\": [\n    \"1.0.7\",\n    \"1.0.6\",\n    \"1.0.5\",\n    \"1.0.4\",\n    \"1.0.3\",\n    \"1.0.2\",\n    \"1.0.1\",\n    \"1.0.0\"\n  ],\n  \"chosen_update\": null,\n  \"most_recent_command\": {\n    \"cmd_status\": \"Success\",\n    \"cmd_type\": \"refresh\",\n    \"exit_status\": 0,\n    \"stderr\": \"\",\n    \"timestamp\": \"2021-04-15T16:48:25.835131261Z\"\n  },\n  \"staging_partition\": null,\n  \"update_state\": \"Idle\"\n}\n","StandardOutputUrl":"","Status":"Success","StatusDetails":"Success"}
2021/04/15 09:48:30 Instance i-########## updated to Bottlerocket 1.0.7
```
3 Bottlerocket instances running a  Service and 1 with no tasks: 

```
BR - 1
$ apiclient update check
04:27:15 [INFO] Refreshing updates...
{
  "active_partition": {
    "image": {
      "arch": "x86_64",
      "variant": "aws-ecs-1",
      "version": "1.0.7"
    },

BR - 2
$ apiclient update check
04:27:15 [INFO] Refreshing updates...
{
  "active_partition": {
    "image": {
      "arch": "x86_64",
      "variant": "aws-ecs-1",
      "version": "1.0.7"
    },

BR - 3

$ apiclient update check
04:27:59 [INFO] Refreshing updates...
{
  "active_partition": {
    "image": {
      "arch": "x86_64",
      "variant": "aws-ecs-1",
      "version": "1.0.7"
    },
 
BR - 4

$ apiclient update check
04:28:31 [INFO] Refreshing updates...
{
  "active_partition": {
    "image": {
      "arch": "x86_64",
      "variant": "aws-ecs-1",
      "version": "1.0.7"
    },
```



The previous, updated, instances were then replaced with 1.0.5 instances and a non-service tasks placed into the cluster, running on BR-1: 

```
BR-1 
{
  "active_partition": {
    "image": {
      "arch": "x86_64",
      "variant": "aws-ecs-1",
      "version": "1.0.5"
    },

BR-2
{
  "active_partition": {
    "image": {
      "arch": "x86_64",
      "variant": "aws-ecs-1",
      "version": "1.0.8"
    },
    "next_to_boot": true
  },

 BR-3
{
  "active_partition": {
    "image": {
      "arch": "x86_64",
      "variant": "aws-ecs-1",
      "version": "1.0.8"
    },

BR-4
{
  "active_partition": {
    "image": {
      "arch": "x86_64",
      "variant": "aws-ecs-1",
      "version": "1.0.7"
    },
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
