### PR TITLE
Restructure Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,21 +4,35 @@ UPDATER_TARGET_ARCH      = amd64
 
 # the docker image that will be used to compile go code
 BUILDER_IMAGE = public.ecr.aws/bottlerocket/bottlerocket-sdk-${BOTTLEROCKET_SDK_ARCH}:${BOTTLEROCKET_SDK_VERSION}
+SOURCEDIR=./updater
+SOURCES := $(shell find $(SOURCEDIR) -name '*.go')
+export GO111MODULE=on
 
-.PHONY: fetch-dependency # downloads go.mod dependency
-fetch-dependency:
-	cd updater && GO111MODULE=on go mod tidy
+all: build
+
+.PHONY: tidy
+tidy:
+	cd updater && go mod tidy
 
 .PHONY: build # builds updater
-build: fetch-dependency
+build: updater/bin/bottlerocket-ecs-updater
+updater/bin/bottlerocket-ecs-updater: $(SOURCES) updater/go.mod updater/go.sum
 	GOARCH=$(UPDATER_TARGET_ARCH)
-	cd updater && GO111MODULE=on go build -v -o bin/bottlerocket-ecs-updater .
+	cd updater && go build -v -o bin/bottlerocket-ecs-updater .
+
+.PHONY: test
+test:
+	cd updater && go test -v ./...
+
 
 .PHONY: image # creates a docker image with the updater binary
-image: build
+image:
 	DOCKER_BUILDKIT=1 \
 	docker build \
 		-t bottlerocket-ecs-updater:latest \
 		--build-arg BUILDER_IMAGE=${BUILDER_IMAGE} \
 		--build-arg GOARCH=${UPDATER_TARGET_ARCH} \
 		"${PWD}/updater"
+
+clean:
+	-rm -rf updater/bin


### PR DESCRIPTION
**Description of changes:**
This commit makes several changes to the Makefile
1. Define a default target via `all`
2. Track source files for the build so no rebuild is necessary when there are no source changes
3. Add a test target
4. Remove unnecessary dependency from the image target to the build target, as the image target performs its own rebuild inside Docker


**Testing done:**
```
$ make
GOARCH=amd64
cd updater && GO111MODULE=on go build -v -o bin/bottlerocket-ecs-updater .
$ make
make: Nothing to be done for 'all'.
$ make clean
$ make
GOARCH=amd64
cd updater && GO111MODULE=on go build -v -o bin/bottlerocket-ecs-updater .
$ touch updater/go.mod
$ make
GOARCH=amd64
cd updater && GO111MODULE=on go build -v -o bin/bottlerocket-ecs-updater .
$ touch updater/main.go 
$ make
GOARCH=amd64
cd updater && GO111MODULE=on go build -v -o bin/bottlerocket-ecs-updater .
$ make
make: Nothing to be done for 'all'.
$ make test
cd updater && GO111MODULE=on go test -v ./...
?   	github.com/bottlerocket-os/bottlerocket-ecs-updater	[no test files]
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
