### PR TITLE
Refactored map of instanceID and containerInstanceID to struct

### DIFF
--- a/updater/aws_test.go
+++ b/updater/aws_test.go
@@ -37,9 +37,15 @@ func TestFilterBottlerocketInstances(t *testing.T) {
 			Ec2InstanceId:        aws.String("ec2-id-not2"),
 		}},
 	}
-	expected := map[string]string{
-		"ec2-id-br1": "cont-inst-br1",
-		"ec2-id-br2": "cont-inst-br2",
+	expected := []instance{
+		{
+			instanceID:          "ec2-id-br1",
+			containerInstanceID: "cont-inst-br1",
+		},
+		{
+			instanceID:          "ec2-id-br2",
+			containerInstanceID: "cont-inst-br2",
+		},
 	}
 
 	mockECS := MockECS{


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
Minor refactoring to use consistent data-structure: list of `struct instance` to contain all instances that are currently under consideration.


**Testing done:**
1. Ran `make test`
2. Launched an empty ECS cluster and saw it return "Zero instance in the cluster"
3. Added a Bottlerocket v1.0.6 instance to the cluster and saw it getting updated to v1.0.8
4. Ran the application again to make sure it does not find any new instances to update.
5.  Added another Bottlerocket v1.0.6 instance to the cluster, now there are two instances one which can be updated and other is already update.  Saw only one instance getting updated to v1.0.8


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
