### PR TITLE
Set Waiter Options to Tune MaxAttempts & Delay

### DIFF
--- a/updater/mock_test.go
+++ b/updater/mock_test.go
@@ -1,14 +1,18 @@
 package main
 
-import "github.com/aws/aws-sdk-go/service/ecs"
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/ecs"
+)
 
 type MockECS struct {
-	ListContainerInstancesFn        func(input *ecs.ListContainerInstancesInput) (*ecs.ListContainerInstancesOutput, error)
-	DescribeContainerInstancesFn    func(input *ecs.DescribeContainerInstancesInput) (*ecs.DescribeContainerInstancesOutput, error)
-	UpdateContainerInstancesStateFn func(input *ecs.UpdateContainerInstancesStateInput) (*ecs.UpdateContainerInstancesStateOutput, error)
-	ListTasksFn                     func(input *ecs.ListTasksInput) (*ecs.ListTasksOutput, error)
-	DescribeTasksFn                 func(input *ecs.DescribeTasksInput) (*ecs.DescribeTasksOutput, error)
-	WaitUntilTasksStoppedFn         func(input *ecs.DescribeTasksInput) error
+	ListContainerInstancesFn           func(input *ecs.ListContainerInstancesInput) (*ecs.ListContainerInstancesOutput, error)
+	DescribeContainerInstancesFn       func(input *ecs.DescribeContainerInstancesInput) (*ecs.DescribeContainerInstancesOutput, error)
+	UpdateContainerInstancesStateFn    func(input *ecs.UpdateContainerInstancesStateInput) (*ecs.UpdateContainerInstancesStateOutput, error)
+	ListTasksFn                        func(input *ecs.ListTasksInput) (*ecs.ListTasksOutput, error)
+	DescribeTasksFn                    func(input *ecs.DescribeTasksInput) (*ecs.DescribeTasksOutput, error)
+	WaitUntilTasksStoppedWithContextFn func(ctx aws.Context, input *ecs.DescribeTasksInput, opts ...request.WaiterOption) error
 }
 
 var _ ECSAPI = (*MockECS)(nil)
@@ -33,6 +37,6 @@ func (m MockECS) DescribeTasks(input *ecs.DescribeTasksInput) (*ecs.DescribeTask
 	return m.DescribeTasksFn(input)
 }
 
-func (m MockECS) WaitUntilTasksStopped(input *ecs.DescribeTasksInput) error {
-	return m.WaitUntilTasksStoppedFn(input)
+func (m MockECS) WaitUntilTasksStoppedWithContext(ctx aws.Context, input *ecs.DescribeTasksInput, opts ...request.WaiterOption) error {
+	return m.WaitUntilTasksStoppedWithContextFn(ctx, input, opts...)
 }


### PR DESCRIPTION
**Issue number:**
Rectify issue #41 


**Description of changes:**

Set MaxAttempts and Delay options for WaitUntilTasksStopped and WaitUntilCommandExecuted waiters. The current values for two constants, waiterDelay and waiterMaxAttempts, are guided by my testing while developing a similar solution. Even though the tests were not exhaustive(12-15 attempts), P99 time for task drain was 600 seconds. The observed time for SSM was similar, however, the approach used was slightly different from current one. This number guides the current aggregate value for the waiters timeout: 1500 seconds (15 * 100), which is 2.5X the observed value. Due to the nature of both the waiters, this upper bound gives the updater significant headroom for longer drain or SSM command run times while allowing for a reasonable (~15 seconds) exit, when successful. 

**Testing done:**
1. Ran ```make test```
2. Pushed change to feature branch, verified Go linting workflow was created and that it executed as expected for push actions. Created a draft pull request to verify functionality in pull requests.
3. Execution of changes with 2 Bottlerocket ECS instances at version 1.0.5 (output truncated for brevity):

```
-----------------------------------------------------
2021/05/07 18:20:04 DEBUG: Response ssm/GetCommandInvocation Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 400 Bad Request
Connection: keep-alive
Content-Type: application/x-amz-json-1.1
Date: Fri, 07 May 2021 22:20:04 GMT
Server: Server
X-Amzn-Requestid: 1af49e53-faa7-4576-be4d-65e441685824


-----------------------------------------------------

2021/05/07 18:20:19 DEBUG: Response ssm/GetCommandInvocation Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 200 OK
Connection: keep-alive
Content-Type: application/x-amz-json-1.1
Date: Fri, 07 May 2021 22:20:19 GMT
Server: Server
X-Amzn-Requestid: b9be8ebc-48c2-4636-93cc-3555af06960f


-----------------------------------------------------

-----------------------------------------------------
2021/05/07 18:20:19 {"CloudWatchOutputConfig":{"CloudWatchLogGroupName":"","CloudWatchOutputEnabled":false},"CommandId":"78c8da26-9361-486a-8a19-5ec8105326a4","Comment":"","DocumentName":"AWS-RunShellScript","DocumentVersion":"$DEFAULT","ExecutionElapsedTime":"PT1.126S","ExecutionEndDateTime":"2021-05-07T22:20:06.056Z","ExecutionStartDateTime":"2021-05-07T22:20:05.056Z","InstanceId":"i-0eb6d6f84e3ce6ea6","PluginName":"aws:runShellScript","ResponseCode":0,"StandardErrorContent":"22:20:05 [INFO] Refreshing updates...\n","StandardErrorUrl":"","StandardOutputContent":"{\n  \"active_partition\": {\n    \"image\": {\n      \"arch\": \"x86_64\",\n      \"variant\": \"aws-ecs-1\",\n      \"version\": \"1.0.8\"\n    },\n    \"next_to_boot\": true\n  },\n  \"available_updates\": [\n    \"1.0.8\",\n    \"1.0.7\",\n    \"1.0.6\",\n    \"1.0.5\",\n    \"1.0.4\",\n    \"1.0.3\",\n    \"1.0.2\",\n    \"1.0.1\",\n    \"1.0.0\"\n  ],\n  \"chosen_update\": null,\n  \"most_recent_command\": {\n    \"cmd_status\": \"Success\",\n    \"cmd_type\": \"refresh\",\n    \"exit_status\": 0,\n    \"stderr\": \"\",\n    \"timestamp\": \"2021-05-07T22:20:06.137235464Z\"\n  },\n  \"staging_partition\": null,\n  \"update_state\": \"Idle\"\n}\n","StandardOutputUrl":"","Status":"Success","StatusDetails":"Success"}
2021/05/07 18:20:19 Instance {`i-0eb6d6f84e3ce6ea6` `arn:aws:ecs:us-east-1:807080734664:container-instance/BottlerocketStack-RocketClusterOutdated1D5EE92A-kCUzoayjPg3i/bf5d3420dfdd463486e056dcefca173a`} updated successfully
2021/05/07 18:20:19 Instance {`i-0eb6d6f84e3ce6ea6` `arn:aws:ecs:us-east-1:807080734664:container-instance/BottlerocketStack-RocketClusterOutdated1D5EE92A-kCUzoayjPg3i/bf5d3420dfdd463486e056dcefca173a`} running Bottlerocket: 1.0.8


```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
