### PR TITLE
Add pagination to listContainerInstances

### DIFF
--- a/updater/aws_test.go
+++ b/updater/aws_test.go
@@ -9,6 +9,46 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestListContainerInstances(t *testing.T) {
+	output := &ecs.ListContainerInstancesOutput{
+		ContainerInstanceArns: []*string{
+			aws.String("cont-inst-arn1"),
+			aws.String("cont-inst-arn2"),
+			aws.String("cont-inst-arn3")},
+		NextToken: aws.String("token"),
+	}
+	output2 := &ecs.ListContainerInstancesOutput{
+		ContainerInstanceArns: []*string{
+			aws.String("cont-inst-arn4"),
+			aws.String("cont-inst-arn5"),
+			aws.String("cont-inst-arn6")},
+		NextToken: nil,
+	}
+	expected := []*string{
+		aws.String("cont-inst-arn1"),
+		aws.String("cont-inst-arn2"),
+		aws.String("cont-inst-arn3"),
+		aws.String("cont-inst-arn4"),
+		aws.String("cont-inst-arn5"),
+		aws.String("cont-inst-arn6")}
+
+	mockECS := MockECS{
+		ListContainerInstancesPagesFn: func(_ *ecs.ListContainerInstancesInput, fn func(*ecs.ListContainerInstancesOutput, bool) bool) error {
+			fn(output, true)
+			fn(output2, false)
+			return nil
+		},
+		ListContainerInstancesFn: func(_ *ecs.ListContainerInstancesInput) (*ecs.ListContainerInstancesOutput, error) {
+			return output, nil
+		},
+	}
+	u := updater{ecs: mockECS}
+
+	actual, err := u.listContainerInstances()
+	require.NoError(t, err)
+	assert.EqualValues(t, expected, actual)
+}
+
 func TestFilterBottlerocketInstances(t *testing.T) {
 	output := &ecs.DescribeContainerInstancesOutput{
 		ContainerInstances: []*ecs.ContainerInstance{{
@@ -37,9 +77,15 @@ func TestFilterBottlerocketInstances(t *testing.T) {
 			Ec2InstanceId:        aws.String("ec2-id-not2"),
 		}},
 	}
-	expected := map[string]string{
-		"ec2-id-br1": "cont-inst-br1",
-		"ec2-id-br2": "cont-inst-br2",
+	expected := []instance{
+		{
+			instanceID:          "ec2-id-br1",
+			containerInstanceID: "cont-inst-br1",
+		},
+		{
+			instanceID:          "ec2-id-br2",
+			containerInstanceID: "cont-inst-br2",
+		},
 	}
 
 	mockECS := MockECS{

--- a/updater/mock_test.go
+++ b/updater/mock_test.go
@@ -4,6 +4,7 @@ import "github.com/aws/aws-sdk-go/service/ecs"
 
 type MockECS struct {
 	ListContainerInstancesFn        func(input *ecs.ListContainerInstancesInput) (*ecs.ListContainerInstancesOutput, error)
+	ListContainerInstancesPagesFn   func(input *ecs.ListContainerInstancesInput, fn func(*ecs.ListContainerInstancesOutput, bool) bool) error
 	DescribeContainerInstancesFn    func(input *ecs.DescribeContainerInstancesInput) (*ecs.DescribeContainerInstancesOutput, error)
 	UpdateContainerInstancesStateFn func(input *ecs.UpdateContainerInstancesStateInput) (*ecs.UpdateContainerInstancesStateOutput, error)
 	ListTasksFn                     func(input *ecs.ListTasksInput) (*ecs.ListTasksOutput, error)
@@ -15,6 +16,10 @@ var _ ECSAPI = (*MockECS)(nil)
 
 func (m MockECS) ListContainerInstances(input *ecs.ListContainerInstancesInput) (*ecs.ListContainerInstancesOutput, error) {
 	return m.ListContainerInstancesFn(input)
+}
+
+func (m MockECS) ListContainerInstancesPages(input *ecs.ListContainerInstancesInput, fn func(*ecs.ListContainerInstancesOutput, bool) bool) error {
+	return m.ListContainerInstancesPagesFn(input, fn)
 }
 
 func (m MockECS) DescribeContainerInstances(input *ecs.DescribeContainerInstancesInput) (*ecs.DescribeContainerInstancesOutput, error) {


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Addresses: https://github.com/bottlerocket-os/bottlerocket-ecs-updater/issues/36
Addresses: https://github.com/bottlerocket-os/bottlerocket-ecs-updater/issues/37


**Description of changes:**
Adds pagination to ListContainerInstances API call and updates dependent methods to process paginated results in batches. Added unit test to cover `listContainerInstances` method.


**Testing done:**
1. Executed the change against ECS Test cluster with 3 instances and the max results for ListContainerInstances set to 1. Results truncated for brevity:
```
-----------------------------------------------------
Instances ready for update: [{`i-0d2074d37f9a21df2` `arn:aws:ecs:us-west-2:518928554640:container-instance/updater-test-cluster/0a0699395646444489149dcd692af1b1`}
 {`i-035558bcf0ce5ea43` `arn:aws:ecs:us-west-2:518928554640:container-instance/updater-test-cluster/7857f0b52688437a88b15a5dce870e8f`} 
{`i-02d7af7b5aaf023d8` `arn:aws:ecs:us-west-2:518928554640:container-instance/updater-test-cluster/cefde97ea8164f82b8ad412675659451`}]
```
Above instances were destroyed after test execution. 

2. Executed `make test`: 
```
$ make test
cd updater && go test -v ./...
=== RUN   TestListContainerInstances
--- PASS: TestListContainerInstances (0.00s)
=== RUN   TestFilterBottlerocketInstances
2021/05/12 17:17:37 Bottlerocket instance detected. Instance ec2-id-br1 added to check updates
2021/05/12 17:17:37 Bottlerocket instance detected. Instance ec2-id-br2 added to check updates
--- PASS: TestFilterBottlerocketInstances (0.00s)
PASS
ok      github.com/bottlerocket-os/bottlerocket-ecs-updater     0.053s
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
