### PR TITLE
Add pagination to listContainerInstances

### DIFF
--- a/updater/main.go
+++ b/updater/main.go
@@ -22,7 +22,7 @@ var (
 type updater struct {
 	cluster string
 	ecs     ECSAPI
-	ssm     *ssm.SSM
+	ssm     SSMAPI
 	ec2     *ec2.EC2
 }
 

--- a/updater/mock_test.go
+++ b/updater/mock_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go/service/ssm"
 )
 
 type MockECS struct {
@@ -13,6 +14,13 @@ type MockECS struct {
 	WaitUntilTasksStoppedFn         func(input *ecs.DescribeTasksInput) error
 }
 
+type MockSSM struct {
+	WaitUntilCommandExecutedFn func(input *ssm.GetCommandInvocationInput) error
+	SendCommandFn              func(input *ssm.SendCommandInput) (*ssm.SendCommandOutput, error)
+	GetCommandInvocationFn     func(input *ssm.GetCommandInvocationInput) (*ssm.GetCommandInvocationOutput, error)
+}
+
+var _ SSMAPI = (*MockSSM)(nil)
 var _ ECSAPI = (*MockECS)(nil)
 
 func (m MockECS) ListContainerInstancesPages(input *ecs.ListContainerInstancesInput, fn func(*ecs.ListContainerInstancesOutput, bool) bool) error {
@@ -37,4 +45,16 @@ func (m MockECS) DescribeTasks(input *ecs.DescribeTasksInput) (*ecs.DescribeTask
 
 func (m MockECS) WaitUntilTasksStopped(input *ecs.DescribeTasksInput) error {
 	return m.WaitUntilTasksStoppedFn(input)
+}
+
+func (m MockSSM) SendCommand(input *ssm.SendCommandInput) (*ssm.SendCommandOutput, error) {
+	return m.SendCommandFn(input)
+}
+
+func (m MockSSM) WaitUntilCommandExecuted(input *ssm.GetCommandInvocationInput) error {
+	return m.WaitUntilCommandExecutedFn(input)
+}
+
+func (m MockSSM) GetCommandInvocation(input *ssm.GetCommandInvocationInput) (*ssm.GetCommandInvocationOutput, error) {
+	return m.GetCommandInvocationFn(input)
 }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Addresses: https://github.com/bottlerocket-os/bottlerocket-ecs-updater/issues/36
Addresses: https://github.com/bottlerocket-os/bottlerocket-ecs-updater/issues/37


**Description of changes:**
Adds pagination to ListContainerInstances API call and updates dependent methods to process paginated results in batches. Added unit test to cover `listContainerInstances` method.


**Testing done:**
1. Executed the change against ECS Test cluster with 3 instances and the max results for ListContainerInstances set to 1. Results truncated for brevity:
```
-----------------------------------------------------
Instances ready for update: [{`i-0d2074d37f9a21df2` `arn:aws:ecs:us-west-2:518928554640:container-instance/updater-test-cluster/0a0699395646444489149dcd692af1b1`}
 {`i-035558bcf0ce5ea43` `arn:aws:ecs:us-west-2:518928554640:container-instance/updater-test-cluster/7857f0b52688437a88b15a5dce870e8f`} 
{`i-02d7af7b5aaf023d8` `arn:aws:ecs:us-west-2:518928554640:container-instance/updater-test-cluster/cefde97ea8164f82b8ad412675659451`}]
```
Above instances were destroyed after test execution. 

2. Executed `make test`: 
```
$ make test
cd updater && go test -v ./...
=== RUN   TestListContainerInstances
--- PASS: TestListContainerInstances (0.00s)
=== RUN   TestFilterBottlerocketInstances
2021/05/12 17:17:37 Bottlerocket instance detected. Instance ec2-id-br1 added to check updates
2021/05/12 17:17:37 Bottlerocket instance detected. Instance ec2-id-br2 added to check updates
--- PASS: TestFilterBottlerocketInstances (0.00s)
PASS
ok      github.com/bottlerocket-os/bottlerocket-ecs-updater     0.053s
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
