### PR TITLE
Update refactor and Compare versions for validating update

### DIFF
--- a/updater/main.go
+++ b/updater/main.go
@@ -112,9 +112,14 @@ func _main() error {
 			return fmt.Errorf("instance %#q failed to re-activate after update: %w", i, activateErr)
 		}
 
-		err = u.verifyUpdate(i)
+		ok, err := u.verifyUpdate(i)
 		if err != nil {
 			log.Printf("Failed to verify update for instance %#q: %v", i, err)
+		}
+		if !ok {
+			log.Printf("Update failed for instance %#q", i)
+		} else {
+			log.Printf("Instance %#q updated successfully!", i)
 		}
 	}
 	return nil


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#48 , Partial #40



**Description of changes:**
This PR includes 3 commits:
 
   1. Refactor logs for do update and verify update step

   2. Refactor parsing check command output
    
    Previously, there were separate methods for getting active version
    and update state. However in all the cases, we need both the fields together.
    So, this change adds a method to parse the raw bytes of command output and
    extract all the fields required in a struct

   3. Fixed update verification
    
    Previously version before update was not stored, so it was hard to verify
    if update happened or not. This change stores the version and compares it with
    updated version to report appropriate logs.


**Testing done:**

1. Added an instance to the cluster and saw it updated completely with proper logs.
2. Ran make test



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
