### PR TITLE
Fixed a stack deploy failure bug caused by missing Resource field

### DIFF
--- a/stacks/bottlerocket-ecs-updater.yaml
+++ b/stacks/bottlerocket-ecs-updater.yaml
@@ -63,6 +63,7 @@ Resources:
                   - 'ecs:ListTasks'
                   - 'ecs:UpdateContainerInstancesState'
                   - 'ecs:DescribeTasks'
+                Resource: '*'
                 Condition:
                   ArnEquals:
                     ecs:cluster: !Sub 'arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}'


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A



**Description of changes:**
Resource field is required in addition to condition field for task role policy actions. This change adds the missing Resource field.


**Testing done:**
1. Deployed stack and verified correct Policy Json.
2. Added instances to the cluster and saw them getting updated.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
