### PR TITLE
Add Status filter to listContianerInstances

### DIFF
--- a/updater/aws.go
+++ b/updater/aws.go
@@ -34,9 +34,10 @@ func (u *updater) listContainerInstances() ([]*string, error) {
 	resp, err := u.ecs.ListContainerInstances(&ecs.ListContainerInstancesInput{
 		Cluster:    &u.cluster,
 		MaxResults: aws.Int64(pageSize),
+		Status:     aws.String("ACTIVE"),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("cannot list container instances: %#v", err)
+		return nil, fmt.Errorf("cannot list container instances: %w", err)
 	}
 	log.Printf("%#v", resp)
 	return resp.ContainerInstanceArns, nil

--- a/updater/aws_test.go
+++ b/updater/aws_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -8,6 +9,65 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestListContainerInstances(t *testing.T) {
+	cases := []struct {
+		name          string
+		listOutput    *ecs.ListContainerInstancesOutput
+		listError     error
+		expectedError string
+		expectedOut   []*string
+	}{
+		{
+			name: "with instances",
+			listOutput: &ecs.ListContainerInstancesOutput{
+				ContainerInstanceArns: []*string{
+					aws.String("cont-inst-arn1"),
+					aws.String("cont-inst-arn2"),
+					aws.String("cont-inst-arn3")},
+			},
+			expectedOut: []*string{
+				aws.String("cont-inst-arn1"),
+				aws.String("cont-inst-arn2"),
+				aws.String("cont-inst-arn3"),
+			},
+		},
+		{
+			name: "without instances",
+			listOutput: &ecs.ListContainerInstancesOutput{
+				ContainerInstanceArns: []*string{},
+			},
+			expectedOut: []*string{},
+		},
+		{
+			name:          "list fail",
+			listError:     errors.New("failed to list instances"),
+			expectedError: "cannot list container instances",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockECS := MockECS{
+				ListContainerInstancesFn: func(input *ecs.ListContainerInstancesInput) (*ecs.ListContainerInstancesOutput, error) {
+					assert.Equal(t, int64(pageSize), aws.Int64Value(input.MaxResults))
+					assert.Equal(t, "ACTIVE", aws.StringValue(input.Status))
+					return tc.listOutput, tc.listError
+				},
+			}
+			u := updater{ecs: mockECS}
+			actual, err := u.listContainerInstances()
+			if tc.expectedOut != nil {
+				assert.EqualValues(t, tc.expectedOut, actual)
+				assert.NoError(t, err)
+			} else {
+				assert.Empty(t, actual)
+				assert.ErrorIs(t, err, tc.listError)
+				assert.Contains(t, err.Error(), tc.expectedError)
+			}
+		})
+	}
+}
 
 func TestFilterBottlerocketInstances(t *testing.T) {
 	output := &ecs.DescribeContainerInstancesOutput{


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Addresses #57 


**Description of changes:**
Adds the "Status" filter to `listContainerInstances` to ensure that only instances in an "ACTIVE" status are listed for operations.


**Testing done:**
ran `make test`
```
$ make test
cd updater && go test -v ./...
=== RUN   TestListContainerInstances
=== RUN   TestListContainerInstances/with_instances
2021/05/25 16:57:50 {
  ContainerInstanceArns: ["cont-inst-arn1","cont-inst-arn2","cont-inst-arn3"]
}
=== RUN   TestListContainerInstances/without_instances
2021/05/25 16:57:50 {
  ContainerInstanceArns: []
}
=== RUN   TestListContainerInstances/list_fail
--- PASS: TestListContainerInstances (0.00s)
    --- PASS: TestListContainerInstances/with_instances (0.00s)
    --- PASS: TestListContainerInstances/without_instances (0.00s)
    --- PASS: TestListContainerInstances/list_fail (0.00s)
=== RUN   TestFilterBottlerocketInstances
2021/05/25 16:57:50 Bottlerocket instance detected. Instance ec2-id-br1 added to check updates
2021/05/25 16:57:50 Bottlerocket instance detected. Instance ec2-id-br2 added to check updates
--- PASS: TestFilterBottlerocketInstances (0.00s)
PASS
ok      github.com/bottlerocket-os/bottlerocket-ecs-updater   
```
Executed change against ECS Test cluster with one Instance in a draining state, i-00f19ef9651bfa2da: 

```
$ ./bottlerocket-ecs-updater -cluster updater-test-cluster -region us-west-2
2021/05/20 16:54:05 Bottlerocket instance detected. Instance i-0a11f852284f882e6 added to check updates
2021/05/20 16:54:05 Bottlerocket instance detected. Instance i-08c331c4b1f871199 added to check updates
2021/05/20 16:54:05 Sending SSM command "apiclient update check"
2021/05/20 16:54:10 CommandID: d366316f-f750-40ad-a8de-670d1a090989
2021/05/20 16:54:10 Instances ready for update: [{`i-0a11f852284f882e6` `arn:aws:ecs:us-west-2:518928554640:container-instance/updater-test-cluster/87c011e8371d4df7bc564cea6cac1602`} {`i-08c331c4b1f871199` `arn:aws:ecs:us-west-2:518928554640:container-instance/updater-test-cluster/b80513ab6b684ced8b1ebd75d18a9470`}]
```

Above instances destroyed after testing. 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
