### PR TITLE
Add error handling to WaitUntilCommandExecuted

### DIFF
--- a/updater/main.go
+++ b/updater/main.go
@@ -29,7 +29,7 @@ type updater struct {
 	applyDocument  string
 	rebootDocument string
 	ecs            ECSAPI
-	ssm            *ssm.SSM
+	ssm            SSMAPI
 	ec2            *ec2.EC2
 }
 

--- a/updater/mock_test.go
+++ b/updater/mock_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go/service/ssm"
 )
 
 type MockECS struct {
@@ -16,6 +17,14 @@ type MockECS struct {
 }
 
 var _ ECSAPI = (*MockECS)(nil)
+
+type MockSSM struct {
+	WaitUntilCommandExecutedWithContextFn func(ctx aws.Context, input *ssm.GetCommandInvocationInput, opts ...request.WaiterOption) error
+	SendCommandFn                         func(input *ssm.SendCommandInput) (*ssm.SendCommandOutput, error)
+	GetCommandInvocationFn                func(input *ssm.GetCommandInvocationInput) (*ssm.GetCommandInvocationOutput, error)
+}
+
+var _ SSMAPI = (*MockSSM)(nil)
 
 func (m MockECS) ListContainerInstances(input *ecs.ListContainerInstancesInput) (*ecs.ListContainerInstancesOutput, error) {
 	return m.ListContainerInstancesFn(input)
@@ -39,4 +48,16 @@ func (m MockECS) DescribeTasks(input *ecs.DescribeTasksInput) (*ecs.DescribeTask
 
 func (m MockECS) WaitUntilTasksStoppedWithContext(ctx aws.Context, input *ecs.DescribeTasksInput, opts ...request.WaiterOption) error {
 	return m.WaitUntilTasksStoppedWithContextFn(ctx, input, opts...)
+}
+
+func (m MockSSM) SendCommand(input *ssm.SendCommandInput) (*ssm.SendCommandOutput, error) {
+	return m.SendCommandFn(input)
+}
+
+func (m MockSSM) WaitUntilCommandExecutedWithContext(ctx aws.Context, input *ssm.GetCommandInvocationInput, opts ...request.WaiterOption) error {
+	return m.WaitUntilCommandExecutedWithContextFn(ctx, input, opts...)
+}
+
+func (m MockSSM) GetCommandInvocation(input *ssm.GetCommandInvocationInput) (*ssm.GetCommandInvocationOutput, error) {
+	return m.GetCommandInvocationFn(input)
 }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Addresses #63 


**Description of changes:**
Adds error handling to `sendCommand`'s `WaitUntilCommandExecuted` waiter. 


**Testing done:**
ran `make test`:

```
$ make test
cd updater && go test -v ./...
=== RUN   TestSendCommand
=== RUN   TestSendCommand/send_success
2021/05/27 17:13:44 Sending SSM document "test-doc"
2021/05/27 17:13:44 SSM document "test-doc" posted with command id "id1"
=== RUN   TestSendCommand/send_fail
2021/05/27 17:13:44 Sending SSM document "test-doc"
=== RUN   TestSendCommand/wait_single_failure
2021/05/27 17:13:44 Sending SSM document "test-doc"
2021/05/27 17:13:44 Error encountered while awaiting document "test-doc" execution for instance: inst-id-1: exceeded max attempts
=== RUN   TestSendCommand/wait_one_succcess
2021/05/27 17:13:44 Sending SSM document "test-doc"
2021/05/27 17:13:44 Error encountered while awaiting document "test-doc" execution for instance: inst-id-1: exceeded max attempts
2021/05/27 17:13:44 Error encountered while awaiting document "test-doc" execution for instance: inst-id-2: exceeded max attempts
2021/05/27 17:13:44 SSM document "test-doc" posted with command id "id1"
=== RUN   TestSendCommand/wait_fail_all
2021/05/27 17:13:44 Sending SSM document "test-doc"
2021/05/27 17:13:44 Error encountered while awaiting document "test-doc" execution for instance: inst-id-1: exceeded max attempts
2021/05/27 17:13:44 Error encountered while awaiting document "test-doc" execution for instance: inst-id-2: exceeded max attempts
2021/05/27 17:13:44 Error encountered while awaiting document "test-doc" execution for instance: inst-id-3: exceeded max attempts
--- PASS: TestSendCommand (0.00s)
    --- PASS: TestSendCommand/send_success (0.00s)
    --- PASS: TestSendCommand/send_fail (0.00s)
    --- PASS: TestSendCommand/wait_single_failure (0.00s)
    --- PASS: TestSendCommand/wait_one_succcess (0.00s)
    --- PASS: TestSendCommand/wait_fail_all (0.00s)
=== RUN   TestListContainerInstances
=== RUN   TestListContainerInstances/with_instances
2021/05/27 17:13:44 {
  ContainerInstanceArns: ["cont-inst-arn1","cont-inst-arn2","cont-inst-arn3"]
}
=== RUN   TestListContainerInstances/without_instances
2021/05/27 17:13:44 {
  ContainerInstanceArns: []
}
=== RUN   TestListContainerInstances/list_fail
--- PASS: TestListContainerInstances (0.00s)
    --- PASS: TestListContainerInstances/with_instances (0.00s)
    --- PASS: TestListContainerInstances/without_instances (0.00s)
    --- PASS: TestListContainerInstances/list_fail (0.00s)
=== RUN   TestFilterBottlerocketInstances
2021/05/27 17:13:44 Bottlerocket instance detected. Instance ec2-id-br1 added to check updates
2021/05/27 17:13:44 Bottlerocket instance detected. Instance ec2-id-br2 added to check updates
--- PASS: TestFilterBottlerocketInstances (0.00s)
PASS
ok      github.com/bottlerocket-os/bottlerocket-ecs-updater     0.556s
```

The change was also executed against an ECS test cluster. 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
