### PR TITLE
Change scheduled task interval to 12 hours

### DIFF
--- a/stacks/bottlerocket-ecs-updater.yaml
+++ b/stacks/bottlerocket-ecs-updater.yaml
@@ -121,8 +121,8 @@ Resources:
     Type: AWS::Events::Rule
     Properties:
       Description: "Check for Bottlerocket updates on a schedule"
-      # Run Task every 30 minutes
-      ScheduleExpression: "cron(0/30 * * * ? *)"
+      # Run Task every 12 hours
+      ScheduleExpression: "rate(12 hours)"
       State: 'ENABLED'
       Targets:
         - Id: ecs-updater-fargate-task


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Closes #22 

**Description of changes:**
This commit updates the Fargate task schedule to run every 12 hours.



**Testing done:**
Deployed the CloudFormation stack to my ECS Test cluster and observed it running successfully every 12 hours.

```
/ecs/bottlerocket-updater/updater-test-cluster/BottlerocketEcsUpdaterService/901d0f4838274afd8e02e6e08f51b210 | 2021-06-02 02:45:28 (UTC-07:00)

/ecs/bottlerocket-updater/updater-test-cluster/BottlerocketEcsUpdaterService/41338ebdf97d4d708639a0ae11c8b053 | 2021-06-01 14:43:57 (UTC-07:00)
```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
