### PR TITLE
Add pagination functionality

### DIFF
--- a/updater/aws.go
+++ b/updater/aws.go
@@ -15,7 +15,8 @@ import (
 )
 
 const (
-	pageSize             = 50
+	ecsPageSize          = 100
+	ssmPageSize          = 50
 	updateStateIdle      = "Idle"
 	updateStateStaged    = "Staged"
 	updateStateAvailable = "Available"
@@ -42,7 +43,7 @@ type checkOutput struct {
 }
 
 type ECSAPI interface {
-	ListContainerInstances(*ecs.ListContainerInstancesInput) (*ecs.ListContainerInstancesOutput, error)
+	ListContainerInstancesPages(*ecs.ListContainerInstancesInput, func(*ecs.ListContainerInstancesOutput, bool) bool) error
 	DescribeContainerInstances(input *ecs.DescribeContainerInstancesInput) (*ecs.DescribeContainerInstancesOutput, error)
 	UpdateContainerInstancesState(input *ecs.UpdateContainerInstancesStateInput) (*ecs.UpdateContainerInstancesStateOutput, error)
 	ListTasks(input *ecs.ListTasksInput) (*ecs.ListTasksOutput, error)
@@ -62,40 +63,57 @@ type EC2API interface {
 
 func (u *updater) listContainerInstances() ([]*string, error) {
 	log.Printf("Listing active container instances in cluster %q", u.cluster)
-	resp, err := u.ecs.ListContainerInstances(&ecs.ListContainerInstancesInput{
-		Cluster:    &u.cluster,
-		MaxResults: aws.Int64(pageSize),
-		Status:     aws.String("ACTIVE"),
-	})
-	if err != nil {
+	containerInstances := make([]*string, 0)
+	input := &ecs.ListContainerInstancesInput{
+		Cluster: &u.cluster,
+		Status:  aws.String(ecs.ContainerInstanceStatusActive),
+	}
+	if err := u.ecs.ListContainerInstancesPages(input, func(output *ecs.ListContainerInstancesOutput, lastpage bool) bool {
+		containerInstances = append(containerInstances, output.ContainerInstanceArns...)
+		return true
+	}); err != nil {
 		return nil, fmt.Errorf("failed to list container instances: %w", err)
 	}
-	log.Printf("Found %d container instances in the cluster", len(resp.ContainerInstanceArns))
-	return resp.ContainerInstanceArns, nil
+	log.Printf("Found %d container instances in the cluster", len(containerInstances))
+	return containerInstances, nil
 }
 
 // filterBottlerocketInstances filters container instances and returns list of
 // instances that are running Bottlerocket OS
 func (u *updater) filterBottlerocketInstances(instances []*string) ([]instance, error) {
 	log.Printf("Filtering container instances running Bottlerocket OS")
-	resp, err := u.ecs.DescribeContainerInstances(&ecs.DescribeContainerInstancesInput{
-		Cluster:            &u.cluster,
-		ContainerInstances: instances,
+	bottlerocketInstances := make([]instance, 0)
+	errCount := 0
+	var lastErr error
+	pageCount, err := eachPage(len(instances), ecsPageSize, func(start, stop int) error {
+		resp, err := u.ecs.DescribeContainerInstances(&ecs.DescribeContainerInstancesInput{
+			Cluster:            &u.cluster,
+			ContainerInstances: instances[start:stop],
+		})
+		// count errors per page.
+		if err != nil {
+			log.Printf("Failed to describe container instances from %d to %d: %v", start, stop, err)
+			errCount++
+			lastErr = err
+			return nil
+		}
+		for _, containerInstance := range resp.ContainerInstances {
+			if containsAttribute(containerInstance.Attributes, "bottlerocket.variant") {
+				bottlerocketInstances = append(bottlerocketInstances, instance{
+					instanceID:          aws.StringValue(containerInstance.Ec2InstanceId),
+					containerInstanceID: aws.StringValue(containerInstance.ContainerInstanceArn),
+				})
+				log.Printf("Bottlerocket instance %q detected.", aws.StringValue(containerInstance.Ec2InstanceId))
+			}
+		}
+		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to describe container instances: %w", err)
+		return nil, err
 	}
-
-	bottlerocketInstances := make([]instance, 0)
-	// check the DescribeContainerInstances response and add only Bottlerocket instances to the list
-	for _, containerInstance := range resp.ContainerInstances {
-		if containsAttribute(containerInstance.Attributes, "bottlerocket.variant") {
-			bottlerocketInstances = append(bottlerocketInstances, instance{
-				instanceID:          aws.StringValue(containerInstance.Ec2InstanceId),
-				containerInstanceID: aws.StringValue(containerInstance.ContainerInstanceArn),
-			})
-			log.Printf("Bottlerocket instance %q detected", aws.StringValue(containerInstance.Ec2InstanceId))
-		}
+	// check if every page had an error; errors are only fatal if each page failed.
+	if errCount == pageCount {
+		return nil, fmt.Errorf("failed to describe any container instances: %w", lastErr)
 	}
 	return bottlerocketInstances, nil
 }
@@ -110,6 +128,22 @@ func containsAttribute(attrs []*ecs.Attribute, searchString string) bool {
 	return false
 }
 
+// eachPage defines batch processing boundaries for handling paginated results of API calls.
+func eachPage(inputLen int, size int, fn func(start, stop int) error) (int, error) {
+	pageCount := 0
+	for start := 0; start < inputLen; start += size {
+		stop := start + size
+		if stop > inputLen {
+			stop = inputLen
+		}
+		if err := fn(start, stop); err != nil {
+			return 0, err
+		}
+		pageCount++
+	}
+	return pageCount, nil
+}
+
 // filterAvailableUpdates returns a list of instances that have updates available
 func (u *updater) filterAvailableUpdates(bottlerocketInstances []instance) ([]instance, error) {
 	log.Printf("Filtering instances with available updates")
@@ -119,27 +153,42 @@ func (u *updater) filterAvailableUpdates(bottlerocketInstances []instance) ([]in
 		instances = append(instances, inst.instanceID)
 	}
 
-	commandID, err := u.sendCommand(instances, u.checkDocument)
+	var lastErr error
+	errCount := 0
+	candidates := make([]instance, 0)
+	pageCount, err := eachPage(len(instances), ssmPageSize, func(start, stop int) error {
+		commandID, err := u.sendCommand(instances[start:stop], u.checkDocument)
+		if err != nil {
+			// errors here are considered non-fatal.
+			log.Printf("Failed to send document %s: %v", u.checkDocument, err)
+			errCount++
+			lastErr = err
+			return nil
+		}
+		for _, inst := range bottlerocketInstances[start:stop] {
+			commandOutput, err := u.getCommandResult(commandID, inst.instanceID)
+			if err != nil {
+				// errors here are considered non-fatal
+				log.Printf("Failed to get output for command %s, document %s and instance %q: %v", commandID, u.checkDocument, inst, err)
+				continue
+			}
+			output, err := parseCommandOutput(commandOutput)
+			if err != nil {
+				log.Printf("Failed to parse command output %q for instance %q: %v", string(commandOutput), inst, err)
+				continue
+			}
+			if output.UpdateState == updateStateAvailable || output.UpdateState == updateStateReady {
+				inst.bottlerocketVersion = output.ActivePartition.Image.Version
+				candidates = append(candidates, inst)
+			}
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
-
-	candidates := make([]instance, 0)
-	for _, inst := range bottlerocketInstances {
-		commandOutput, err := u.getCommandResult(commandID, inst.instanceID)
-		if err != nil {
-			return nil, err
-		}
-		output, err := parseCommandOutput(commandOutput)
-		if err != nil {
-			// not a fatal error, we can continue checking other instances.
-			log.Printf("Failed to parse command output %q: %v", string(commandOutput), err)
-			continue
-		}
-		if output.UpdateState == updateStateAvailable || output.UpdateState == updateStateReady {
-			inst.bottlerocketVersion = output.ActivePartition.Image.Version
-			candidates = append(candidates, inst)
-		}
+	if errCount == pageCount {
+		return nil, fmt.Errorf("all attempts to send SSM document %s failed: %w", u.checkDocument, lastErr)
 	}
 	return candidates, nil
 }

--- a/updater/mock_test.go
+++ b/updater/mock_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 type MockECS struct {
-	ListContainerInstancesFn           func(input *ecs.ListContainerInstancesInput) (*ecs.ListContainerInstancesOutput, error)
+	ListContainerInstancesPagesFn      func(input *ecs.ListContainerInstancesInput, fn func(*ecs.ListContainerInstancesOutput, bool) bool) error
 	DescribeContainerInstancesFn       func(input *ecs.DescribeContainerInstancesInput) (*ecs.DescribeContainerInstancesOutput, error)
 	UpdateContainerInstancesStateFn    func(input *ecs.UpdateContainerInstancesStateInput) (*ecs.UpdateContainerInstancesStateOutput, error)
 	ListTasksFn                        func(input *ecs.ListTasksInput) (*ecs.ListTasksOutput, error)
@@ -33,8 +33,8 @@ type MockEC2 struct {
 
 var _ EC2API = (*MockEC2)(nil)
 
-func (m MockECS) ListContainerInstances(input *ecs.ListContainerInstancesInput) (*ecs.ListContainerInstancesOutput, error) {
-	return m.ListContainerInstancesFn(input)
+func (m MockECS) ListContainerInstancesPages(input *ecs.ListContainerInstancesInput, fn func(*ecs.ListContainerInstancesOutput, bool) bool) error {
+	return m.ListContainerInstancesPagesFn(input, fn)
 }
 
 func (m MockECS) DescribeContainerInstances(input *ecs.DescribeContainerInstancesInput) (*ecs.DescribeContainerInstancesOutput, error) {


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Addresses #36 


**Description of changes:**
Adds pagination to necessary API calls and
updates dependent functions to utilize paginated results
in batches.


**Testing done:**
ran `make test`

Built and executed changes against ECS Test cluster with 3 Bottlerocket instances joined and with `ecsPageSize` and `ssmPageSize` set to 1. 

Results below truncated for brevity: 
```
Instances ready for update: [{`i-051b9fc99f51ec6d0` `arn:aws:ecs:us-west-2:518928554640:container-instance/updater-test-cluster/4794f80c2cc84fa0868951a22e7891bb` `1.0.5`} {`i-0d2e0c34c6ca77207` `arn:aws:ecs:us-west-2:518928554640:container-instance/updater-test-cluster/67fc8268e73a4d31aa8c0b96611c15e9` `1.0.5`} {`i-01c078c8ad8918049` `arn:aws:ecs:us-west-2:518928554640:container-instance/updater-test-cluster/d049c2a97e184f1791e47064a2a67715` `1.0.5`}]


2021/06/03 16:25:08 Container instance "arn:aws:ecs:us-west-2:518928554640:container-instance/updater-test-cluster/4794f80c2cc84fa0868951a22e7891bb" updated to version "1.1.1"
2021/06/03 16:25:08 Instance {`i-051b9fc99f51ec6d0` `arn:aws:ecs:us-west-2:518928554640:container-instance/updater-test-cluster/4794f80c2cc84fa0868951a22e7891bb` `1.0.5`} updated successfully!


2021/06/03 16:26:45 Container instance "arn:aws:ecs:us-west-2:518928554640:container-instance/updater-test-cluster/67fc8268e73a4d31aa8c0b96611c15e9" updated to version "1.1.1"
2021/06/03 16:26:45 Instance {`i-0d2e0c34c6ca77207` `arn:aws:ecs:us-west-2:518928554640:container-instance/updater-test-cluster/67fc8268e73a4d31aa8c0b96611c15e9` `1.0.5`} updated successfully!

2021/06/03 16:28:23 Container instance "arn:aws:ecs:us-west-2:518928554640:container-instance/updater-test-cluster/d049c2a97e184f1791e47064a2a67715" updated to version "1.1.1"
2021/06/03 16:28:23 Instance {`i-01c078c8ad8918049` `arn:aws:ecs:us-west-2:518928554640:container-instance/updater-test-cluster/d049c2a97e184f1791e47064a2a67715` `1.0.5`} updated successfully!
```
All instances listed above were destroyed after testing. 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
