### PR TITLE
Fixed bug in integ setup script

### DIFF
--- a/integ/setup.sh
+++ b/integ/setup.sh
@@ -99,7 +99,8 @@ if ! aws cloudformation deploy \
     --parameter-overrides \
     IntegSharedResourceStack="${INTEG_STACK_NAME}" \
     InstanceCount="${INSTANCE_COUNT}" \
-    ImageID="${AMI_ID}"; then
+    ImageID="${AMI_ID}" \
+    InstanceType="${INSTANCE_TYPE}"; then
     log ERROR "Failed to deploy stack '${CLUSTER_STACK_TEMPLATE}' stack template"
     exit 1
 fi


### PR DESCRIPTION


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N?A


**Description of changes:**
Previously, integ setup script would always launch `m5.xlarge`( the default instance type) even when `instance-type` argument is provided. This change fixes it.


**Testing done:**
1. Used setup script to start a cluster with `p3.2xlarge` instance type.



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
