### PR TITLE
Added more details to eligible logs

### DIFF
--- a/updater/aws.go
+++ b/updater/aws.go
@@ -168,6 +168,7 @@ func (u *updater) eligible(containerInstance string) (bool, error) {
 	for _, listResult := range desc.Tasks {
 		startedBy := aws.StringValue(listResult.StartedBy)
 		if !strings.HasPrefix(startedBy, "ecs-svc/") {
+			log.Printf("Container instance %q has a non-service task running: %s", containerInstance, aws.StringValue(listResult.TaskArn))
 			return false, nil
 		}
 	}

--- a/updater/main.go
+++ b/updater/main.go
@@ -109,7 +109,7 @@ func _main() error {
 			continue
 		}
 		if !eligible {
-			log.Printf("Instance %#q is not eligible for updates", i)
+			log.Printf("Instance %#q is not eligible for updates because it contains non-service task", i)
 			continue
 		}
 		log.Printf("Instance %q is eligible for update", i)


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
During bug-bash there was lots of confusion why few instances were not updated. This change updates eligible logs to add additional details.


**Testing done:**
Ran updater task on a cluster and verified below logs.
```
2021/06/16 16:56:01 Checking eligiblity for update of container instance "arn:aws:ecs:us-west-2:062205370538:container-instance/ecs-updater-integ-cluster/7be585ea55514ca6956c2fc88dcc1b5b"

2021/06/16 16:56:01 Container instance "arn:aws:ecs:us-west-2:062205370538:container-instance/ecs-updater-integ-cluster/7be585ea55514ca6956c2fc88dcc1b5b" has running non-service task arn:aws:ecs:us-west-2:062205370538:task/ecs-updater-integ-cluster/1ef47efe0a8146c28d1fb43ba5ff97fe
2021/06/16 16:56:01 Instance {`i-02e9ef063aead69f6` `arn:aws:ecs:us-west-2:062205370538:container-instance/ecs-updater-integ-cluster/7be585ea55514ca6956c2fc88dcc1b5b` `1.0.7`} is not eligible for updates because it contains non-service task
```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
