### PR TITLE
Logs command invocation output when ssm command fails in wait

### DIFF
--- a/updater/aws.go
+++ b/updater/aws.go
@@ -371,6 +371,7 @@ func (u *updater) sendCommand(instanceIDs []string, ssmDocument string) (string,
 		if err != nil {
 			errCount++
 			log.Printf("Error encountered while awaiting document %q execution for instance: %q: %s", ssmDocument, v, err)
+			u.logCommmandOutput(commandID, v)
 		}
 	}
 	// TODO return a list of instanceIDs which ecnountered no waiter errors.
@@ -390,6 +391,18 @@ func (u *updater) getCommandResult(commandID string, instanceID string) ([]byte,
 	}
 	commandResults := []byte(aws.StringValue(resp.StandardOutputContent))
 	return commandResults, nil
+}
+
+// logCommmandOutput logs the ssm command invocation response
+func (u *updater) logCommmandOutput(commandID string, instanceID string) {
+	resp, err := u.ssm.GetCommandInvocation(&ssm.GetCommandInvocationInput{
+		CommandId:  aws.String(commandID),
+		InstanceId: aws.String(instanceID),
+	})
+	if err != nil {
+		log.Printf("Failed to get invocation output for instance %q: %v", instanceID, err)
+	}
+	log.Printf("Invocation output for instance %q: %#q", instanceID, resp)
 }
 
 // waitUntilOk takes an EC2 ID as a parameter and waits until the specified EC2 instance is in an Ok status.


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**



**Description of changes:**
During bug-bash it was noticed that error logs are not clear when ssm command failed to complete. This changes logs the
complete command invocation output on failure.


**Testing done:**
1. Unit tests.
2. Ran updater on cluster with incorrect Update URL.
```
Waiting for command "05d46a98-bf72-417c-b056-ab1b240d122c" to complete for instance "i-0cfce16cd2c332082"
2021/06/17 14:29:08 Error encountered while awaiting document "UPDATER-updater-messed-update-url-UpdateCheckCommand-a1M4znpBLGBY" execution for instance: "i-0cfce16cd2c332082": ResourceNotReady: failed waiting for successful resource state
2021/06/17 14:29:08 Invocation output for instance "i-0cfce16cd2c332082": "{\n  CloudWatchOutputConfig: {\n    CloudWatchLogGroupName: \"\",\n    CloudWatchOutputEnabled: false\n  },\n  CommandId: \"05d46a98-bf72-417c-b056-ab1b240d122c\",\n  Comment: \"\",\n  DocumentName: \"UPDATER-updater-messed-update-url-UpdateCheckCommand-a1M4znpBLGBY\",\n  DocumentVersion: \"$DEFAULT\",\n  ExecutionElapsedTime: \"PT0.314S\",\n  ExecutionEndDateTime: \"2021-06-17T18:28:53.301Z\",\n  ExecutionStartDateTime: \"2021-06-17T18:28:53.301Z\",\n  InstanceId: \"i-0cfce16cd2c332082\",\n  PluginName: \"CheckUpdate\",\n  ResponseCode: 1,\n  StandardErrorContent: \"18:28:53 \\x1b[0m\\x1b[34m[INFO] \\x1b[0mRefreshing updates...\\nFailed to check for updates: refresh attempt failed with status 'Failed' (-1): Metadata error: Failed to fetch https://updates.bottlerocket.aws/2020-07-07/aws-ecs-1/x86_6/timestamp.json: Transport 'file not found' error fetching 'https://updates.bottlerocket.aws/2020-07-07/aws-ecs-1/x86_6/timestamp.json?seed=503&version=1.0.7': File not found: HTTP status client error (403 Forbidden) for url (https://updates.bottlerocket.aws/2020-07-07/aws-ecs-1/x86_6/timestamp.json?seed=503&version=1.0.7)\\n\\nfailed to run commands: exit status 1\",\n  StandardErrorUrl: \"\",\n  StandardOutputContent: \"\",\n  StandardOutputUrl: \"\",\n  Status: \"Failed\",\n  StatusDetails: \"Failed\"\n}"
2021/06/17 14:29:08 Failed to check updates: too many failures while awaiting document execution: ResourceNotReady: failed waiting for successful resource state

```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
