### PR TITLE
Added timeout seconds for ssm command

### DIFF
--- a/updater/aws.go
+++ b/updater/aws.go
@@ -22,6 +22,8 @@ const (
 	updateStateReady     = "Ready"
 	waiterDelay          = time.Duration(15) * time.Second
 	waiterMaxAttempts    = 100
+	// If this time is reached and the ssm command has not already started running, it will not run.
+	deliveryTimeoutSeconds = 600
 )
 
 type instance struct {
@@ -296,6 +298,7 @@ func (u *updater) updateInstance(inst instance) error {
 		DocumentName:    aws.String(u.rebootDocument),
 		DocumentVersion: aws.String("$DEFAULT"),
 		InstanceIds:     aws.StringSlice(ec2IDs),
+		TimeoutSeconds:  aws.Int64(deliveryTimeoutSeconds),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to send reboot command: %w", err)
@@ -351,6 +354,7 @@ func (u *updater) sendCommand(instanceIDs []string, ssmDocument string) (string,
 		DocumentName:    aws.String(ssmDocument),
 		DocumentVersion: aws.String("$DEFAULT"),
 		InstanceIds:     aws.StringSlice(instanceIDs),
+		TimeoutSeconds:  aws.Int64(deliveryTimeoutSeconds),
 	})
 	if err != nil {
 		return "", fmt.Errorf("send command failed: %w", err)


### PR DESCRIPTION


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
If ECS execution role is deleted, SSM command will not be delivered, and by default the delivery timeout time is 3600 seconds or 1hour. This change adds a delivery timeout of 600 seconds or 10 min so that waiters does not have to wait so long for SSM command to complete. After this change SSM command timeouts after 10 min (timeout) + 30 min (execution timeout) = 40min.


**Testing done:**
1. Ran updater on a cluster after deleting Execution role policy. Before it took 1 hour 30 min to timeout, after this change it takes only 40min.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
