### PR TITLE
Updated Readme.md to mention minimum Bottlerocket version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ A container instance may be skipped for update when:
   If draining has not completed by the end of the period, the updater will restore the instance and move to the next one.
   The time it takes for a task to be stopped is related to the `stopTimeout` task definition parameter and to any associated resources like load balancers.
   If your tasks are taking too long to drain, you can ensure that your task responds to `SIGTERM`, shorten the `stopTimeout`, or shorten the load balancer's health check and deregistration delay settings.
+* _Bottlerocket version is too old._
+  The Bottlerocket ECS Updater uses newer [`apiclient update` commands](https://github.com/bottlerocket-os/bottlerocket#update-api) that were added in version [1.0.5](https://github.com/bottlerocket-os/bottlerocket/blob/develop/CHANGELOG.md#v105-2021-01-15).
+  The SSM commands will fail if your Bottlerocket OS version is less than 1.0.5.
+  Instances running Bottlerocket versions less than 1.0.5 need to be manually updated.
 
 ### Why do new container instances launch with older Bottlerocket versions?
 


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
During bug-bash some developers started using Bottlerocket AMI version less than 1.0.6. Due to this there were some errors in the log but it was not clear what was wrong. This change updates the Readme to mention the minimum Bottlerocket version requirement for ECS Updater service to work.


**Testing done:**
1. Launched cluster with instances running v1.0.4 and v1.0.5 and saw updates running fine for 1.0.5 and fail for 1.0.4


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
