### PR TITLE
quote raw command output in errors

### DIFF
--- a/updater/aws.go
+++ b/updater/aws.go
@@ -133,7 +133,7 @@ func (u *updater) filterAvailableUpdates(bottlerocketInstances []instance) ([]in
 		output, err := parseCommandOutput(commandOutput)
 		if err != nil {
 			// not a fatal error, we can continue checking other instances.
-			log.Printf("Failed to parse command output %s: %v", string(commandOutput), err)
+			log.Printf("Failed to parse command output %q: %v", string(commandOutput), err)
 			continue
 		}
 		if output.UpdateState == updateStateAvailable || output.UpdateState == updateStateReady {
@@ -268,7 +268,7 @@ func (u *updater) updateInstance(inst instance) error {
 	}
 	check, err := parseCommandOutput(output)
 	if err != nil {
-		return fmt.Errorf("failed to parse command output %s: %w", string(output), err)
+		return fmt.Errorf("failed to parse command output %q: %w", string(output), err)
 	}
 
 	switch check.UpdateState {
@@ -331,7 +331,7 @@ func (u *updater) verifyUpdate(inst instance) (bool, error) {
 	}
 	output, err := parseCommandOutput(updateResult)
 	if err != nil {
-		return false, fmt.Errorf("failed to parse command output %s, manual verification required: %w", string(updateResult), err)
+		return false, fmt.Errorf("failed to parse command output %q, manual verification required: %w", string(updateResult), err)
 	}
 	updatedVersion := output.ActivePartition.Image.Version
 	if updatedVersion == inst.bottlerocketVersion {

--- a/updater/aws_test.go
+++ b/updater/aws_test.go
@@ -952,7 +952,7 @@ func TestVerifyUpdateErr(t *testing.T) {
 			bottlerocketVersion: "0.0.0",
 		})
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to parse command output , manual verification required")
+		assert.Contains(t, err.Error(), `failed to parse command output "", manual verification required`)
 		assert.False(t, ok)
 	})
 }


### PR DESCRIPTION
**Description of changes:**
Raw command output can be empty.  When parsing errors occur and we log the raw output, it may appear like this:

```
Failed to parse command output : failed to unmarshal json: unexpected end of JSON input
```

This change uses the [`%q` format verb](https://golang.org/pkg/fmt/) to quote and escape the output.

**Testing done:**
* `make lint`
* `make test`


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
