### PR TITLE
Deletes services and tasks before cleaning up cluster.

### DIFF
--- a/integ/cleanup.sh
+++ b/integ/cleanup.sh
@@ -58,6 +58,7 @@ delete_stack() {
     if ! aws cloudformation delete-stack \
         --stack-name "${stack_name}"; then
         log ERROR "Failed to delete '${stack_name}'"
+        return
     fi
 
     log INFO "Waiting for Cloudformation stack '${stack_name}' to be deleted"
@@ -66,6 +67,7 @@ delete_stack() {
         log ERROR "Failed to wait for ${stack_name} to delete"
         aws cloudformation describe-stack-events \
             --stack-name "${stack_name}"
+        return
     fi
     log INFO "Cloudformation stack '${stack_name}' deleted!"
 }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#91 


**Description of changes:**
Stopped tasks and deleted services before deleting the cluster stack.


**Testing done:**
1. Launched a cluster with 2 instances and started updater task and a service on it. On calling the clean up script cluster and all it instances were deleted successfully.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
