### PR TITLE
Updater continues on failure to change INACTIVE container instance state

### DIFF
--- a/updater/aws.go
+++ b/updater/aws.go
@@ -221,6 +221,10 @@ func (u *updater) activateInstance(containerInstance string) error {
 		return fmt.Errorf("failed to change state to ACTIVE: %w", err)
 	}
 	if len(resp.Failures) != 0 {
+		if aws.StringValue(resp.Failures[0].Reason) == "INACTIVE" {
+			log.Printf("Container instance %q is in INACTIVE state", containerInstance)
+			return nil
+		}
 		return fmt.Errorf("API failures while activating: %v", resp.Failures)
 	}
 	log.Printf("Container instance %q state changed to ACTIVE successfully!", containerInstance)


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
Previously, if instance is terminated in between updates, updater would stop after failing to change the container instance state to Active. With this change container instance state change failure for INACTIVE container instance is not considered fatal.


**Testing done:**
1. Started updater on a cluster and terminated instances in between of update to reach expected state.


Stop in between update apply
```


2021/06/28 21:14:05 SSM document "UPDATER-ecs-updater-integ-cluster-UpdateApplyCommand-RIG8SnxYwC09" posted with command id "433aa91d-57db-4e4a-a540-861411047c1a"
--
2021/06/28 21:14:05 Waiting for command "433aa91d-57db-4e4a-a540-861411047c1a" to complete for instance "i-06f2d2027616fb142"
2021/06/28 21:18:50 Error encountered while awaiting document "UPDATER-ecs-updater-integ-cluster-UpdateApplyCommand-RIG8SnxYwC09" execution for instance: "i-06f2d2027616fb142": ResourceNotReady: exceeded wait attempts
2021/06/28 21:18:50 Invocation output for instance "i-06f2d2027616fb142": "{\n  CloudWatchOutputConfig: {\n    CloudWatchLogGroupName: \"\",\n    CloudWatchOutputEnabled: false\n  },\n  CommandId: \"433aa91d-57db-4e4a-a540-861411047c1a\",\n  Comment: \"\",\n  DocumentName: \"UPDATER-ecs-updater-integ-cluster-UpdateApplyCommand-RIG8SnxYwC09\",\n  DocumentVersion: \"$DEFAULT\",\n  ExecutionEndDateTime: \"\",\n  InstanceId: \"i-06f2d2027616fb142\",\n  PluginName: \"ApplyUpdate\",\n  ResponseCode: -1,\n  StandardErrorContent: \"\",\n  StandardErrorUrl: \"\",\n  StandardOutputContent: \"\",\n  StandardOutputUrl: \"\",\n  Status: \"InProgress\",\n  StatusDetails: \"InProgress\"\n}"
2021/06/28 21:18:50 Container instance "arn:aws:ecs:us-west-2:062205370538:container-instance/ecs-updater-integ-cluster/8f9c6325b05d433e8133d3cf15f38f9f" is in INACTIVE state
2021/06/28 21:18:50 Failed to update instance {`i-06f2d2027616fb142` `arn:aws:ecs:us-west-2:062205370538:container-instance/ecs-updater-integ-cluster/8f9c6325b05d433e8133d3cf15f38f9f` `1.0.7`}: failed to send update apply command: too many failures while awaiting document execution: ResourceNotReady: exceeded wait attempts


```

Stop in between reboot
```
2021/06/28 21:03:47 Sending SSM document "UPDATER-ecs-updater-integ-cluster-RebootCommand-NzLHsdeQSy5q" on instance "i-0b15aedcb132ca1cd"
--
2021/06/28 21:03:47 SSM document "UPDATER-ecs-updater-integ-cluster-RebootCommand-NzLHsdeQSy5q" posted with command ID "0d89b5ae-0288-47c2-9911-b6a1019dede5"
2021/06/28 21:04:02 Waiting for instance "i-0b15aedcb132ca1cd" to reach Ok status
2021/06/28 21:13:49 Container instance "arn:aws:ecs:us-west-2:062205370538:container-instance/ecs-updater-integ-cluster/74ada171d49e4f288e93fe501686919a" is in INACTIVE state
2021/06/28 21:13:49 Failed to update instance {`i-0b15aedcb132ca1cd` `arn:aws:ecs:us-west-2:062205370538:container-instance/ecs-updater-integ-cluster/74ada171d49e4f288e93fe501686919a` `1.0.7`}: failed to reach Ok status after reboot: ResourceNotReady: exceeded wait attempts

```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
