### PR TITLE
Updater stack creates Loggroup if it does not exist

### DIFF
--- a/stacks/bottlerocket-ecs-updater.yaml
+++ b/stacks/bottlerocket-ecs-updater.yaml
@@ -31,6 +31,17 @@ Resources:
                 - 'ecs-tasks.amazonaws.com'
             Action:
               - 'sts:AssumeRole'
+      Policies:
+        - PolicyName: CreateLogGroupPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              # Allows creating log group if it does not exist
+              - Effect: Allow
+                Action:
+                  - 'logs:CreateLogGroup'
+                Resource:
+                  - 'arn:aws:logs:*:*:*'
       Path: !Sub /${AWS::StackName}/
       ManagedPolicyArns:
         - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy'
@@ -119,6 +130,7 @@ Resources:
           LogConfiguration:
             LogDriver: awslogs
             Options:
+              awslogs-create-group: 'true'
               awslogs-region: !Ref AWS::Region
               awslogs-group: !Ref LogGroupName
               awslogs-stream-prefix: !Sub '/ecs/bottlerocket-updater/${ClusterName}'


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
Previously, Updater would error out if provided log group name does not
exist. With this change updater creates a loggroup with retention time of never expire, if it does not exist. 
For existing loggroup there will be no change.


**Testing done:**
1. Started Updater stack on a cluster with non-existing log group name and saw it getting created and logstream published.
2. Started Updater stack on same cluster with existing log group and saw log stream getting published without issue.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
