### PR TITLE
Prevent multiple updater task run

### DIFF
--- a/stacks/bottlerocket-ecs-updater.yaml
+++ b/stacks/bottlerocket-ecs-updater.yaml
@@ -133,6 +133,21 @@ Resources:
         - Id: ecs-updater-fargate-task
           RoleArn: !GetAtt CronRole.Arn
           Arn: !Sub 'arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}'
+          Input:
+             !Sub |
+              {
+                  "containerOverrides": [
+                      {
+                         "name": "BottlerocketEcsUpdaterService",
+                         "environment": [
+                             {
+                                 "name" : "TASK_DEFINITION_ARN",
+                                 "value": "${UpdaterTaskDefinition}"
+                             }
+                         ]
+                      }
+                  ]
+              }
           EcsParameters:
             LaunchType: FARGATE
             TaskCount: 1

--- a/updater/main_test.go
+++ b/updater/main_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTaskDefFamily(t *testing.T) {
+	cases := []struct {
+		name           string
+		taskDefARN     string
+		expectedErr    string
+		expectedFamily string
+	}{
+		{
+			name:           "success",
+			taskDefARN:     "arn:aws:ecs:us-west-2:1234567:task-definition/updater-family:1",
+			expectedFamily: "updater-family",
+		},
+		{
+			name:           "fail parse arn",
+			taskDefARN:     "arn:ecs:us-west-2:1234567updater-family:1",
+			expectedFamily: "",
+			expectedErr:    "arn: not enough sections",
+		},
+		{
+			name:           "fail empty arn",
+			taskDefARN:     "",
+			expectedFamily: "",
+			expectedErr:    "arn: invalid prefix",
+		},
+		{
+			name:           "fail extract family",
+			taskDefARN:     "arn:aws:ecs:us-west-2:1234567:task-def/updater-family1",
+			expectedFamily: "",
+			expectedErr:    "not a task definition arn:",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			originalValue := os.Getenv(taskDefARNEnv)
+			defer func() { os.Setenv(taskDefARNEnv, originalValue) }()
+			os.Setenv(taskDefARNEnv, tc.taskDefARN)
+			family, err := taskDefFamily()
+			if tc.expectedErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedErr)
+			}
+			assert.Equal(t, tc.expectedFamily, family)
+		})
+	}
+}


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#12 


**Description of changes:**
Previously, updater scheduling interval was set to 12 hours which can help mitigate multiple updater operating on the cluster. But, there was still a possibility. With this change, we stop the updater run if there is another updater operating on the cluster.


**Testing done:**
1. unit tests.
2. Updated updater stack with scheduling interval of 2 minute so that multiple updater runs are triggered. After first run, concurrent updater runs are stopped with log:
```
2021/07/01 17:35:53 Updater task definition family: "ecs-updater-loggroup-create-UpdaterTaskDefinition-lQIJmO1EIypA"
--
2021/07/01 17:35:53 Checking for running updater tasks
2021/07/01 17:35:53 Another updater is running, therefore exiting this run.

```
Successful running task logs:
```

2021/07/01 17:32:34 Updater task definition family: "ecs-updater-loggroup-create-UpdaterTaskDefinition-lQIJmO1EIypA"
--
2021/07/01 17:32:34 Checking for running updater tasks
2021/07/01 17:32:34 This is the only running updater.
2021/07/01 17:32:34 Listing active container instances in cluster "bottlerocket-ecs"
```
3. Integ test script
```
--
2021/07/07 18:53:29 Failed to parse updater task definition arn: arn: invalid prefix
2021/07/07 18:53:29 Ignoring check for already running updater

```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
