### PR TITLE
Add success verification to getCommandResult

### DIFF
--- a/updater/aws.go
+++ b/updater/aws.go
@@ -463,6 +463,9 @@ func (u *updater) getCommandResult(commandID string, instanceID string) ([]byte,
 		return nil, fmt.Errorf("failed to retrieve command invocation output: %w", err)
 	}
 	commandResults := []byte(aws.StringValue(resp.StandardOutputContent))
+	if aws.StringValue(resp.Status) != ssm.CommandInvocationStatusSuccess {
+		return nil, fmt.Errorf("command %s has not reached success status, current status %q", commandID, aws.StringValue(resp.Status))
+	}
 	return commandResults, nil
 }
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
https://github.com/bottlerocket-os/bottlerocket-ecs-updater/issues/70


**Description of changes:**
Adds command invocation success verification to getCommandResult to ensure
only successful instances are passed on for operations.


**Testing done:**
ran `make test`: 

```
PASS
ok      github.com/bottlerocket-os/bottlerocket-ecs-updater     45.406s
```

Executed against test cluster and verified instances updated as expected:

```
2021/07/07 16:38:32 Container instance "arn:aws:ecs:us-west-2:518928554640:container-instance/updater-test-cluster/d0b280b596ca478e8a294e33ebaea5fc" updated to version "1.1.2"
2021/07/07 16:38:32 Instance {`i-0cda72c54999dd642` `arn:aws:ecs:us-west-2:518928554640:container-instance/updater-test-cluster/d0b280b596ca478e8a294e33ebaea5fc` `1.0.5`} updated successfully!
``` 
Above instance(s) were destroyed after testing. 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
