### PR TITLE
Add WaitGroup to sendCommand

### DIFF
--- a/updater/aws_test.go
+++ b/updater/aws_test.go
@@ -90,7 +90,7 @@ func TestSendCommandSuccess(t *testing.T) {
 	commandID, err := u.sendCommand(instances, "test-doc")
 	require.NoError(t, err)
 	assert.EqualValues(t, "command-id", commandID)
-	assert.Equal(t, instances, waitInstanceIDs)
+	assert.ElementsMatch(t, instances, waitInstanceIDs)
 }
 
 func TestSendCommandErr(t *testing.T) {
@@ -153,7 +153,7 @@ func TestSendCommandWaitErr(t *testing.T) {
 			require.Error(t, err)
 			assert.ErrorIs(t, err, waitError)
 			assert.Equal(t, "", commandID)
-			assert.Equal(t, tc.instances, failedInstanceIDs, "should match instances for which wait fail")
+			assert.ElementsMatch(t, tc.instances, failedInstanceIDs, "should match instances for which wait fails")
 		})
 	}
 }
@@ -168,8 +168,8 @@ func TestSendCommandWaitSuccess(t *testing.T) {
 	t.Run("wait one success", func(t *testing.T) {
 		// commandSuccessInstance indicates an instance for which the command should succeed
 		const commandSuccessInstance = "inst-success"
-		instances := []string{"inst-id-1", "inst-id-1", commandSuccessInstance}
-		expectedFailInstances := []string{"inst-id-1", "inst-id-1"}
+		instances := []string{"inst-id-1", "inst-id-2", commandSuccessInstance}
+		expectedFailInstances := []string{"inst-id-1", "inst-id-2"}
 		failedInstanceIDs := []string{}
 		mockSSM := MockSSM{
 			SendCommandFn: mockSendCommand,
@@ -189,10 +189,10 @@ func TestSendCommandWaitSuccess(t *testing.T) {
 		commandID, err := u.sendCommand(instances, "test-doc")
 		require.NoError(t, err)
 		assert.Equal(t, "command-id", commandID)
-		assert.Equal(t, expectedFailInstances, failedInstanceIDs, "should match instances for which wait fail")
+		assert.ElementsMatch(t, expectedFailInstances, failedInstanceIDs, "should match instances for which wait fails")
 	})
 	t.Run("wait all success", func(t *testing.T) {
-		instances := []string{"inst-id-1", "inst-id-1"}
+		instances := []string{"inst-id-1", "inst-id-2"}
 		waitInstanceIDs := []string{}
 		mockSSM := MockSSM{
 			SendCommandFn: mockSendCommand,
@@ -206,7 +206,7 @@ func TestSendCommandWaitSuccess(t *testing.T) {
 		commandID, err := u.sendCommand(instances, "test-doc")
 		require.NoError(t, err)
 		assert.Equal(t, "command-id", commandID)
-		assert.Equal(t, instances, waitInstanceIDs)
+		assert.ElementsMatch(t, instances, waitInstanceIDs, "should match instances for which wait succeeds")
 	})
 
 }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Closes #37 


**Description of changes:**
This change adds WaitGroup to `sendCommand` to prevent edge cases where long running commands
get garbage collected before execution status is retrieved.


**Testing done:**
ran `make test` : 

```
PASS
ok      github.com/bottlerocket-os/bottlerocket-ecs-updater     49.596s
```

Executed changes against an ECS test cluster and verified successful update actions on test cluster: 

```
2021/07/13 15:27:54 Container instance "arn:aws:ecs:us-west-2:518928554640:container-instance/updater-test-cluster/43dd5fb5949d477c943770caf794990d" updated to version "1.1.2"
2021/07/13 15:27:54 Instance {`i-071b02327101e91d2` `arn:aws:ecs:us-west-2:518928554640:container-instance/updater-test-cluster/43dd5fb5949d477c943770caf794990d` `1.0.5`} updated successfully!

2021/07/13 15:29:16 Container instance "arn:aws:ecs:us-west-2:518928554640:container-instance/updater-test-cluster/f973cfed0d8f42c1b61b66cb8e03cf84" updated to version "1.1.3"
2021/07/13 15:29:16 Instance {`i-065a986fb41aaee3b` `arn:aws:ecs:us-west-2:518928554640:container-instance/updater-test-cluster/f973cfed0d8f42c1b61b66cb8e03cf84` `1.0.5`} updated successfully!
```
Above instances were destroyed after testing. 


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
