### PR TITLE
Remove race conditions in tests that execute `go` routines

### DIFF
--- a/updater/mock_test.go
+++ b/updater/mock_test.go
@@ -20,6 +20,8 @@ type MockECS struct {
 var _ ECSAPI = (*MockECS)(nil)
 
 type MockSSM struct {
+	// WaitUntilCommandExecutedWithContextFn is executed concurrently through
+	// ECS code paths and tests should treat any data in a parallel safe manner
 	WaitUntilCommandExecutedWithContextFn func(ctx aws.Context, input *ssm.GetCommandInvocationInput, opts ...request.WaiterOption) error
 	SendCommandFn                         func(input *ssm.SendCommandInput) (*ssm.SendCommandOutput, error)
 	GetCommandInvocationFn                func(input *ssm.GetCommandInvocationInput) (*ssm.GetCommandInvocationOutput, error)


### PR DESCRIPTION
```
Using a mutex, this patch removes race conditions that
can happen when attempting to increment numbers from
functions that are executed async in go routines.

Signed-off-by: John McBride <jpmmcb@amazon.com>
```

### Description of changes:

Before this patch, I would see intermittent (although rather frequent) off by 1 errors in the tests:

```
--- FAIL: TestPaginatedFilterAvailableUpdatesSuccess (0.00s)
    aws_test.go:151:
                Error Trace:    aws_test.go:151
                Error:          Not equal:
                                expected: 100
                                actual  : 99
                Test:           TestPaginatedFilterAvailableUpdatesSuccess
                Messages:       should wait for each instance
FAIL
FAIL    github.com/bottlerocket-os/bottlerocket-ecs-updater     0.006s
FAIL
```

After some investigation, I found that this is due to a race condition with the following counter:
https://github.com/bottlerocket-os/bottlerocket-ecs-updater/blob/cdaf5f76179428bd83f6f25dac2d35192b9aaea3/updater/aws_test.go#L124

This counter is incremented through the SSM mock:

https://github.com/bottlerocket-os/bottlerocket-ecs-updater/blob/cdaf5f76179428bd83f6f25dac2d35192b9aaea3/updater/aws_test.go#L140-L144

But the problem is that `WaitUntilCommandExecutedWithContextFn` is called from any number of `go` routines that may attempt to increment the variable at the same time resulting in the strange off by 1 errors:

https://github.com/bottlerocket-os/bottlerocket-ecs-updater/blob/cdaf5f76179428bd83f6f25dac2d35192b9aaea3/updater/aws.go#L439-L456

### Testing done:

I now have no flakes occurring and have run the tests through a "fail until" script:
```bash
#!/usr/bin/env bash

echo "Running go tests until fail"
while go test ./... -count=1 -v; do :; done
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
