### PR TITLE
Bump metadata for bottlerocket-ecs-updater image to v0.2.1 release

### DIFF
--- a/stacks/bottlerocket-ecs-updater.yaml
+++ b/stacks/bottlerocket-ecs-updater.yaml
@@ -10,7 +10,7 @@ Parameters:
   UpdaterImage:
     Description: 'Bottlerocket updater container image'
     Type: String
-    Default: 'public.ecr.aws/bottlerocket/bottlerocket-ecs-updater:v0.2.0'
+    Default: 'public.ecr.aws/bottlerocket/bottlerocket-ecs-updater:v0.2.1'
   LogGroupName:
     Description: 'Log group name for Bottlerocket updater logs'
     Type: String


### PR DESCRIPTION
**Issue number:**

Closes: https://github.com/bottlerocket-os/bottlerocket-ecs-updater/issues/105

**Description of changes:**

Updates the metadata for the new ecs-updater image to the newest `v0.2.1` release

**Testing done:**

Pending release

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
