### PR TITLE
Use latest bottlerocket-sdk with newest Go version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # SHELL is set as bash to use some bashisms.
 SHELL = bash
 
-BOTTLEROCKET_SDK_VERSION = v0.27.0
+BOTTLEROCKET_SDK_VERSION = v0.28.0
 BOTTLEROCKET_SDK_ARCH    = x86_64
 UPDATER_TARGET_ARCH      = amd64
 


### PR DESCRIPTION
**Issue number:**

N/a - related to https://github.com/bottlerocket-os/bottlerocket-sdk/pull/84

**Description of changes:**

Uses latest SDK with newest Go version

**Testing done:**

_Coming soon ..._

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
