### PR TITLE
Update metadata for ECS Updater 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.2.2
+
+* Bump version of Go to 1.19.2
+* Upgrade `github.com/aws/aws-sdk-go` dependency to `v1.44.137`
+* Upgrade `github.com/stretchr/testify` dependency to `v1.8.1`
+
 # 0.2.1
 
 * Bump version of Go to 1.19.1 and upgrade dependencies

--- a/stacks/bottlerocket-ecs-updater.yaml
+++ b/stacks/bottlerocket-ecs-updater.yaml
@@ -10,7 +10,7 @@ Parameters:
   UpdaterImage:
     Description: 'Bottlerocket updater container image'
     Type: String
-    Default: 'public.ecr.aws/bottlerocket/bottlerocket-ecs-updater:v0.2.1'
+    Default: 'public.ecr.aws/bottlerocket/bottlerocket-ecs-updater:v0.2.2'
   LogGroupName:
     Description: 'Log group name for Bottlerocket updater logs'
     Type: String


### PR DESCRIPTION
**Issue number:**

Closes #110

**Description of changes:**

Updates metadata for ECS updater in preparation for the 0.2.2 release.

**Testing done:**

N/a

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
