### PR TITLE
Upgrade `ecs-updater` dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # SHELL is set as bash to use some bashisms.
 SHELL = bash
 
-BOTTLEROCKET_SDK_VERSION = v0.28.0
+BOTTLEROCKET_SDK_VERSION = v0.29.0
 BOTTLEROCKET_SDK_ARCH    = x86_64
 UPDATER_TARGET_ARCH      = amd64
 

--- a/updater/go.mod
+++ b/updater/go.mod
@@ -3,7 +3,7 @@ module github.com/bottlerocket-os/bottlerocket-ecs-updater
 go 1.19
 
 require (
-	github.com/aws/aws-sdk-go v1.44.137
+	github.com/aws/aws-sdk-go v1.44.205
 	github.com/stretchr/testify v1.8.1
 )
 

--- a/updater/go.sum
+++ b/updater/go.sum
@@ -1,5 +1,5 @@
-github.com/aws/aws-sdk-go v1.44.137 h1:GH2bUPiW7/gHtB04NxQOSOrKqFNjLGKmqt5YaO+K1SE=
-github.com/aws/aws-sdk-go v1.44.137/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
+github.com/aws/aws-sdk-go v1.44.205 h1:q23NJXgLPIuBMn4zaluWWz57HPP5z7Ut8ZtK1D3N9bs=
+github.com/aws/aws-sdk-go v1.44.205/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related to https://github.com/bottlerocket-os/bottlerocket-sdk/pull/87
and captures using Go 1.19.4

**Description of changes:**

```
- Upgrades aws sdk
- Upgrades bottlerocket sdk image

Signed-off-by: John McBride <jpmmcb@amazon.com>
```

**Testing done:**

Once SDK pr merges and releases, will do integration tests.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
