### PR TITLE
Prepare for ecs updater release

### DIFF
--- a/updater/go.mod
+++ b/updater/go.mod
@@ -3,7 +3,7 @@ module github.com/bottlerocket-os/bottlerocket-ecs-updater
 go 1.19
 
 require (
-	github.com/aws/aws-sdk-go v1.50.17
+	github.com/aws/aws-sdk-go v1.51.20
 	github.com/stretchr/testify v1.8.1
 )
 

--- a/updater/go.sum
+++ b/updater/go.sum
@@ -1,5 +1,5 @@
-github.com/aws/aws-sdk-go v1.50.17 h1:KsbzUKDgGNlkDHGvoQDhiJ63a9jtZd+O+/s3pTOr/ns=
-github.com/aws/aws-sdk-go v1.50.17/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
+github.com/aws/aws-sdk-go v1.51.20 h1:ziM90ujYHKKkoTZL+Wg2LwjbQecL+l298GGJeG4ktZs=
+github.com/aws/aws-sdk-go v1.51.20/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
**Description of changes:**
Updates the aws-sdk-go module to 1.51.20 (time has moved on since @yeazelm updated dependencies), and adds a script to run the `cdk deploy` command for the containerbuilder tool.


**Testing done:**
Built with containerbuilder and tested with `integ/run-updater.sh` (which is the verification that the MCM will use in preflight).


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
